### PR TITLE
Streamlining Marian NMT installation for OpusPocus

### DIFF
--- a/scripts/install_marian_cpu.sh
+++ b/scripts/install_marian_cpu.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+marian_ver="1.12.0"
+marian_dir="marian_cpu"
+build_dir="$marian_dir/build"
+
+n_threads=${1:-1}
+
+if [ -e $marian_dir ] ; then
+    echo "Directory $build_dir already exists" >&2
+    exit 0
+fi
+git clone https://github.com/marian-nmt/marian.git $marian_dir --branch $marian_ver
+
+if [ -e $build_dir ] ; then
+    echo "Directory $build_dir already exists" >&2
+    exit 0
+fi
+mkdir -p $build_dir
+cd $build_dir
+
+cmake .. \
+	-DCMAKE_BUILD_TYPE=Release \
+	-DCOMPILE_CPU=ON \
+	-DCOMPILE_CUDA=OFF \
+	-DUSE_SENTENCEPIECE=ON
+make -j $n_threads 2>&1 | tee $build_dir/build.log

--- a/scripts/install_marian_gpu.sh
+++ b/scripts/install_marian_gpu.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+marian_ver="1.12.0"
+marian_dir="marian_gpu"
+build_dir="$marian_dir/build"
+
+cuda_root=$1
+if [ ! -e $cuda_root ]; then
+	echo "$0 cuda_root_dir cudnn_version [num_threads]" >&2
+	echo "cuda_root_dir ($cuda_root) does not exist" >&2
+	exit 1
+fi
+
+cudnn_ver=$2
+if [ -z $cudnn_ver ]; then
+	echo "$0 cuda_root_dir cudnn_version [num_threads]" >&2
+	echo "cudnn_version was not specified" >&2
+fi
+
+n_threads=${3:-1}
+
+if [ -e $marian_dir ] ; then
+    echo "Directory $build_dir already exists" >&2
+    exit 0
+fi
+git clone https://github.com/marian-nmt/marian.git $marian_dir --branch $marian_ver
+
+if [ -e $build_dir ] ; then
+    echo "Directory $build_dir already exists" >&2
+    exit 0
+fi
+mkdir -p $build_dir
+cd $build_dir
+
+cmake .. \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCOMPILE_CUDA=ON \
+    -DCUDA_TOOLKIT_ROOT_DIR=$cuda_root \
+    -DUSE_CUDNN=ON \
+    -DCUDNN_LIBRARY=$cuda_root/cudnn/$cudnn_ver/lib/libcudnn.so \
+    -DCUDNN_INCLUDE_DIR=$cuda_root/cudnn/$cudnn_ver/include \
+	-DUSE_SENTENCEPIECE=ON
+make -j $n_threads 2>&1 | tee $build_dir/build.log


### PR DESCRIPTION
A suggestion for fix of issue #44.

Includes installation bash scripts for installing marian on CPU and GPU machines in `scripts/`. I based it on our local server configuration so the installation will not be foolproof.
However,
- the scripts should be used when installing marian on github during CI/CD
- the scripts should be included in the Installation documentation (with fixed default paths in relevant steps/configs) to make setup easier for new users
- in cases where the user needs to compile Marian in their own way, it should still help (together with documentation) to setup the configs/paths correctly.

I am looking for the feedback, if you agree with this PR, I'll add additional commit fixing the old paths, configs and documentation.