### PR TITLE
Opustrainer support + Full unit test passing (including runner tests)

### DIFF
--- a/config/marian.train.teacher.12x12.yml
+++ b/config/marian.train.teacher.12x12.yml
@@ -131,8 +131,8 @@ devices:
   - 7
 num-devices: 0
 no-nccl: false
-sharding: local
-sync-freq: 200u
+#sharding: local
+#sync-freq: 200u
 cpu-threads: 0
 mini-batch: 64
 mini-batch-words: 0

--- a/config/marian.train.teacher.12x6.yml
+++ b/config/marian.train.teacher.12x6.yml
@@ -131,8 +131,8 @@ devices:
   - 7
 num-devices: 0
 no-nccl: false
-sharding: local
-sync-freq: 200u
+#sharding: local
+#sync-freq: 200u
 cpu-threads: 0
 mini-batch: 64
 mini-batch-words: 0

--- a/config/marian.train.teacher.base.yml
+++ b/config/marian.train.teacher.base.yml
@@ -15,9 +15,9 @@ save-freq: 5000u
 max-length: 250
 max-length-crop: false
 shuffle: batches
-sharding: global
-sync-freq: 200u
-cpu-threads: 0
+#sharding: global
+#sync-freq: 200u
+#cpu-threads: 0
 mini-batch: 4096
 mini-batch-words: 0
 mini-batch-fit: true

--- a/config/pipeline.train.backtranslation.yml
+++ b/config/pipeline.train.backtranslation.yml
@@ -75,6 +75,10 @@ pipeline:
       train_corpus_step: gather.${global.src_lang}-${global.tgt_lang}
       valid_corpus_step: valid.${global.src_lang}-${global.tgt_lang}
       valid_dataset: ${global.valid_dataset}
+      train_categories:
+        - "clean"
+      train_category_ratios:
+        - 1.0
     - step: train_model
       step_label: train_model.${global.tgt_lang}-${global.src_lang}
       src_lang: ${global.tgt_lang}
@@ -86,6 +90,10 @@ pipeline:
       train_corpus_step: gather.${global.src_lang}-${global.tgt_lang}
       valid_corpus_step: valid.${global.src_lang}-${global.tgt_lang}
       valid_dataset: ${global.valid_dataset}
+      train_categories:
+        - "clean"
+      train_category_ratios:
+        - 1.0
 
     # Translate "mono" data
     - step: translate
@@ -131,6 +139,12 @@ pipeline:
       train_corpus_step: merge.${global.src_lang}-${global.tgt_lang}
       valid_corpus_step: valid.${global.src_lang}-${global.tgt_lang}
       valid_dataset: ${global.valid_dataset}
+      train_categories:
+        - "synthetic.clean"
+        - "organic.clean"
+      train_category_ratios:
+        - 0.5
+        - 0.5
     - step: train_model
       step_label: tune_bt_model.${global.tgt_lang}-${global.src_lang}
       src_lang: ${global.tgt_lang}
@@ -142,6 +156,12 @@ pipeline:
       train_corpus_step: merge.${global.tgt_lang}-${global.src_lang}
       valid_corpus_step: valid.${global.src_lang}-${global.tgt_lang}
       valid_dataset: ${global.valid_dataset}
+      train_categories:
+        - "synthetic.clean"
+        - "organic.clean"
+      train_category_ratios:
+        - 0.5
+        - 0.5
 
     # Eval (iter 2)
     - step: translate

--- a/config/pipeline.train.simple.yml
+++ b/config/pipeline.train.simple.yml
@@ -61,6 +61,10 @@ pipeline:
       train_corpus_step: gather.${global.src_lang}-${global.tgt_lang}
       valid_corpus_step: valid.${global.src_lang}-${global.tgt_lang}
       valid_dataset: ${global.valid_dataset}
+      train_categories:
+        - "clean"
+      train_category_ratios:
+        - 1.0
     - step: train_model
       step_label: train_model.${global.tgt_lang}-${global.src_lang}
       src_lang: ${global.tgt_lang}
@@ -72,6 +76,10 @@ pipeline:
       train_corpus_step: gather.${global.src_lang}-${global.tgt_lang}
       valid_corpus_step: valid.${global.src_lang}-${global.tgt_lang}
       valid_dataset: ${global.valid_dataset}
+      train_categories:
+        - "clean"
+      train_category_ratios:
+        - 1.0
 
     # Eval
     - step: translate

--- a/opuspocus/pipeline_steps/corpus_step.py
+++ b/opuspocus/pipeline_steps/corpus_step.py
@@ -157,6 +157,8 @@ class CorpusStep(OpusPocusStep):
         """By default merges all output dataset shards (if shard_size is not
         None) into the single dataset file.
         """
+        super().command_postprocess()
+
         # By default, all dataset files must be available after a successful
         # step command execution. If not, there must be sharded output that can
         # be concatenated into the target file

--- a/opuspocus/pipeline_steps/generate_vocab.py
+++ b/opuspocus/pipeline_steps/generate_vocab.py
@@ -69,14 +69,18 @@ class GenerateVocabStep(OpusPocusStep):
         return self.corpus_step.output_dir
 
     @property
+    def vocab_path(self) -> Path:
+        return Path(self.output_dir, f"model.{self.src_lang}-{self.tgt_lang}.spm")
+
+    @property
     def languages(self) -> List[str]:
         return [self.src_lang, self.tgt_lang]
 
     def get_command_targets(self) -> List[Path]:
-        return [Path(self.output_dir, f"model.{self.src_lang}-{self.tgt_lang}.spm")]
+        return [self.vocab_path]
 
     def command(self, target_file: Path) -> None:
-        spm_train_path = Path(self.marian_dir, "bin", "spm_train")
+        spm_train_path = Path(self.marian_dir, "build", "spm_train")
         model_prefix = f"{self.output_dir}/{target_file.stem}"
         n_cpus = int(os.environ[RunnerResources.get_env_name("cpus")])
 

--- a/opuspocus/pipeline_steps/merge.py
+++ b/opuspocus/pipeline_steps/merge.py
@@ -27,7 +27,8 @@ class MergeCorpusStep(CorpusStep):
         src_lang: str,
         tgt_lang: str = None,  # noqa: RUF013
         shard_size: Optional[int] = None,
-        merge_categories: bool = False
+        *,
+        merge_categories: bool = False,
     ) -> None:
         super().__init__(
             step=step,
@@ -48,36 +49,37 @@ class MergeCorpusStep(CorpusStep):
         return self.dependencies["other_corpus_step"]
 
     def register_categories(self) -> None:
-        categories_dict = {
-            "categories": [],
-            "mapping": {}
-        }
+        categories_dict = {"categories": [], "mapping": {}}
 
         # Register categories
         for cat in self.prev_corpus_step.categories:
+            cat_val = cat
             if not self.merge_categories:
-                cat = f"{self.previous_corpus_label}.{cat}"
-            categories_dict["categories"].append({"name": cat})
+                cat_val = f"{self.previous_corpus_label}.{cat}"
+            categories_dict["categories"].append({"name": cat_val})
         for cat in self.other_corpus_step.categories:
+            cat_val = cat
             if not self.merge_categories:
-                cat = f"{self.other_corpus_label}.{cat}"
-            if cat not in categories_dict["categories"]:
-                categories_dict["categories"].append({"name": cat})
+                cat_val = f"{self.other_corpus_label}.{cat}"
+            if cat_val not in categories_dict["categories"]:
+                categories_dict["categories"].append({"name": cat_val})
 
         # Register mapping
         for cat, dset_list in self.prev_corpus_step.category_mapping.items():
+            cat_val = cat
             if not self.merge_categories:
-                cat = f"{self.previous_corpus_label}.{cat}"
-            categories_dict["mapping"][cat] = [
+                cat_val = f"{self.previous_corpus_label}.{cat}"
+            categories_dict["mapping"][cat_val] = [
                 f"{self.previous_corpus_label}.{dset_name}" for dset_name in dset_list
             ]
         for cat, dset_list in self.other_corpus_step.category_mapping.items():
+            cat_val = cat
             if not self.merge_categories:
-                cat = f"{self.other_corpus_label}.{cat}"
-            if cat not in categories_dict["mapping"]:
-                categories_dict["mapping"][cat] = []
+                cat_val = f"{self.other_corpus_label}.{cat}"
+            if cat_val not in categories_dict["mapping"]:
+                categories_dict["mapping"][cat_val] = []
             for dset_name in dset_list:
-                categories_dict["mapping"][cat].append(f"{self.other_corpus_label}.{dset_name}")
+                categories_dict["mapping"][cat_val].append(f"{self.other_corpus_label}.{dset_name}")
 
         self.save_categories_dict(categories_dict)
 

--- a/opuspocus/pipeline_steps/merge.py
+++ b/opuspocus/pipeline_steps/merge.py
@@ -5,10 +5,6 @@ from opuspocus.pipeline_steps import register_step
 from opuspocus.pipeline_steps.corpus_step import CorpusStep
 
 
-def extend_dataset_name(dset_name, label):  # noqa: ANN001, ANN201
-    return f"{label}.{dset_name}"
-
-
 @register_step("merge")
 class MergeCorpusStep(CorpusStep):
     """Merge two corpus steps into a single one.
@@ -31,6 +27,7 @@ class MergeCorpusStep(CorpusStep):
         src_lang: str,
         tgt_lang: str = None,  # noqa: RUF013
         shard_size: Optional[int] = None,
+        merge_categories: bool = False
     ) -> None:
         super().__init__(
             step=step,
@@ -43,6 +40,7 @@ class MergeCorpusStep(CorpusStep):
             src_lang=src_lang,
             tgt_lang=tgt_lang,
             shard_size=shard_size,
+            merge_categories=merge_categories,
         )
 
     @property
@@ -50,24 +48,37 @@ class MergeCorpusStep(CorpusStep):
         return self.dependencies["other_corpus_step"]
 
     def register_categories(self) -> None:
-        categories_dict = {}
-        categories_dict["categories"] = [{"name": cat} for cat in self.prev_corpus_step.categories]
+        categories_dict = {
+            "categories": [],
+            "mapping": {}
+        }
 
-        # Merge the category lists
+        # Register categories
+        for cat in self.prev_corpus_step.categories:
+            if not self.merge_categories:
+                cat = f"{self.previous_corpus_label}.{cat}"
+            categories_dict["categories"].append({"name": cat})
         for cat in self.other_corpus_step.categories:
-            if cat not in self.prev_corpus_step.categories:
+            if not self.merge_categories:
+                cat = f"{self.other_corpus_label}.{cat}"
+            if cat not in categories_dict["categories"]:
                 categories_dict["categories"].append({"name": cat})
 
-        categories_dict["mapping"] = {}
+        # Register mapping
         for cat, dset_list in self.prev_corpus_step.category_mapping.items():
+            if not self.merge_categories:
+                cat = f"{self.previous_corpus_label}.{cat}"
             categories_dict["mapping"][cat] = [
-                extend_dataset_name(dset_name, self.previous_corpus_label) for dset_name in dset_list
+                f"{self.previous_corpus_label}.{dset_name}" for dset_name in dset_list
             ]
         for cat, dset_list in self.other_corpus_step.category_mapping.items():
+            if not self.merge_categories:
+                cat = f"{self.other_corpus_label}.{cat}"
             if cat not in categories_dict["mapping"]:
                 categories_dict["mapping"][cat] = []
             for dset_name in dset_list:
-                categories_dict["mapping"][cat].append(extend_dataset_name(dset_name, self.other_corpus_label))
+                categories_dict["mapping"][cat].append(f"{self.other_corpus_label}.{dset_name}")
+
         self.save_categories_dict(categories_dict)
 
     def get_command_targets(self) -> List[Path]:

--- a/opuspocus/pipeline_steps/train_model.py
+++ b/opuspocus/pipeline_steps/train_model.py
@@ -1,24 +1,31 @@
+import argparse
 import logging
 import os
-import signal
+import shutil
 import subprocess
-import sys
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
+
+import yaml
 
 from opuspocus.pipeline_steps import register_step
 from opuspocus.pipeline_steps.corpus_step import CorpusStep
 from opuspocus.pipeline_steps.generate_vocab import GenerateVocabStep
 from opuspocus.pipeline_steps.opuspocus_step import OpusPocusStep
-from opuspocus.utils import RunnerResources, concat_files, subprocess_wait
+from opuspocus.tools import opustrainer_trainer
+from opuspocus.utils import RunnerResources, paste_files
 
 logger = logging.getLogger(__name__)
 
 SLURM_RESUBMIT_TIME = 600  # resubmit N seconds before job finishes
+DEFAULT_MODIFIERS = [{"UpperCase": 0.01}, {"TitleCase": 0.01}]
 
 
 @register_step("train_model")
 class TrainModelStep(OpusPocusStep):
+    opustrainer_config_file = "opustrainer.config.yml"
+    marian_config_file = "marian.config.yml"
+
     def __init__(
         self,
         step: str,
@@ -28,13 +35,16 @@ class TrainModelStep(OpusPocusStep):
         src_lang: str,
         tgt_lang: str,
         marian_config: Path,
-        opustrainer_config: Path,
         vocab_step: GenerateVocabStep,
         train_corpus_step: CorpusStep,
         valid_corpus_step: CorpusStep,
         model_init_step: Optional["TrainModelStep"] = None,
+        opustrainer_config: Optional[Path] = None,
         seed: int = 42,
-        train_category: str = "clean",
+        max_epochs: Optional[int] = None,
+        train_categories: Optional[List[str]] = None,
+        train_category_ratios: Optional[List[float]] = None,
+        train_modifiers: List[Dict[str, Any]] = DEFAULT_MODIFIERS,
         valid_dataset: str = "flores200.dev",
     ) -> None:
         super().__init__(
@@ -45,16 +55,38 @@ class TrainModelStep(OpusPocusStep):
             src_lang=src_lang,
             tgt_lang=tgt_lang,
             marian_config=marian_config,
-            opustrainer_config=opustrainer_config,
             vocab_step=vocab_step,
             train_corpus_step=train_corpus_step,
             valid_corpus_step=valid_corpus_step,
             model_init_step=model_init_step,
+            opustrainer_config=opustrainer_config,
             seed=seed,
-            train_category=train_category,
+            max_epochs=max_epochs,
+            train_categories=train_categories,
+            train_category_ratios=train_category_ratios,
+            train_modifiers=train_modifiers,
             valid_dataset=valid_dataset,
         )
-        # TODO: check language compatibility
+        if opustrainer_config is None and (train_categories is None or train_category_ratios is None):
+            err_msg = (
+                "'train_categories' and 'train_category_ratios' must be provided if 'opustrainer_config' is NoneType."
+            )
+            raise ValueError(err_msg)
+
+        if (train_categories is not None) != (train_category_ratios is not None):
+            err_msg = "'train_categories' and 'train_category_ratios' must be either both specified or both None."
+            raise ValueError(err_msg)
+        if train_categories is not None and train_category_ratios is not None:
+            if len(train_categories) != len(train_category_ratios):
+                err_msg = "'train_categories' and 'train_category_ratios' lists must have same number of elements."
+                raise ValueError(err_msg)
+            if sum(train_category_ratios) != 1.0:
+                err_msg = "'train_category_ratios' list elements must sum up to 1."
+                raise ValueError(err_msg)
+
+        if max_epochs is not None and max_epochs < 0:
+            err_msg = "'max_epochs' must be a positive integer."
+            raise ValueError(err_msg)
 
     def init_step(self) -> None:
         super().init_step()
@@ -64,6 +96,94 @@ class TrainModelStep(OpusPocusStep):
                 "categories.json"
             )
             raise ValueError(err_msg)
+
+        for cat in self.train_categories:
+            if cat not in self.train_corpus_step.categories:
+                err_msg = (
+                    f"One of the 'train_categories' ({cat}) is not part of the 'train_corpus_step' categories "
+                    f"({self.train_corpus_step.categories})."
+                )
+                raise ValueError(err_msg)
+
+        for cat in self.train_corpus_step.categories:
+            if len(self.train_corpus_step.category_mapping[cat]) > 1:
+                logger.warning(
+                    "Category %s contains more than one corpus. Only the first corpus in the list will be "
+                    "considered (%s). To aggregate corpora from individual categories, use GatherCorpusStep prior to "
+                    "training.",
+                    cat,
+                    self.train_corpus_step.category_mapping[cat][0],
+                )
+
+        # Prepare OpusTrainer config
+        if self.opustrainer_config is not None:
+            shutil.copy(self.opustrainer_config, self.opustrainer_config_path)
+        else:
+            with self.opustrainer_config_path.open("w") as fh:
+                yaml.dump(self._generate_opustrainer_config(), fh)
+
+        # Prepare Marian NMT config
+        with self.marian_config_path.open("w") as fh:
+            yaml.dump(self._generate_marian_config(), fh)
+
+    def _generate_opustrainer_config(self) -> Dict[str, Any]:
+        config = {"seed": self.seed, "stages": ["main"], "modifiers": self.train_modifiers, "num_fields": 2}
+
+        categories = self.train_categories
+        if categories is None:
+            categories = self.train_corpus_step.categories
+        config["datasets"] = {
+            cat: str(Path(self.tmp_dir, str(self.train_corpus_step.category_mapping[cat][0]) + ".tsv.gz"))
+            for cat in categories
+        }
+
+        n_epochs = "inf"
+        if self.max_epochs is not None:
+            n_epochs = f"{self.max_epochs}"
+
+        ratios = self.train_category_ratios
+        if ratios is None:
+            ratios = [1.0 / len(categories)] * len(categories)
+        config["main"] = [f"{cat} {ratio:f}" for cat, ratio in zip(categories, ratios)] + [
+            f"until {self.train_categories[0]} {n_epochs}"
+        ]
+        return config
+
+    @property
+    def opustrainer_config_path(self) -> Path:
+        return Path(self.step_dir, self.opustrainer_config_file)
+
+    def _generate_marian_config(self) -> Dict[str, Any]:
+        with self.marian_config.open("r") as fh:
+            config = yaml.safe_load(fh)
+        config["seed"] = self.seed
+        config["model"] = str(self.model_path)
+        config["vocabs"] = [str(self.vocab_path), str(self.vocab_path)]
+        config["dim-vocabs"] = self.vocab_size
+        config["tempdir"] = str(self.tmp_dir)
+        config["valid-translation-output"] = f"{self.log_dir}/valid.out"
+        config["log-level"] = "info"
+        config["log"] = f"{self.log_dir}/train.log"
+        config["valid-log"] = f"{self.log_dir}/valid.log"
+        config["valid-sets"] = f"{self.valid_data_dir}/{self.valid_dataset}.tsv.gz"
+        return config
+
+    @property
+    def opustrainer_config_dict(self) -> Dict[str, Any]:
+        with self.opustrainer_config_path.open("r") as fh:
+            return yaml.safe_load(fh)
+
+    @property
+    def opustrainer_dataset_paths(self) -> List[Path]:
+        return [Path(dset) for dset in self.opustrainer_config_dict["datasets"].values()]
+
+    @property
+    def valid_dataset_path(self) -> Path:
+        return Path(f"{self.valid_data_dir}/{self.valid_dataset}.tsv.gz")
+
+    @property
+    def marian_config_path(self) -> Path:
+        return Path(self.step_dir, self.marian_config_file)
 
     @property
     def train_corpus_step(self) -> CorpusStep:
@@ -82,10 +202,6 @@ class TrainModelStep(OpusPocusStep):
         return self.train_corpus_step.output_dir
 
     @property
-    def train_datasets(self) -> List[str]:
-        return self.train_corpus_step.category_mapping[self.train_category]
-
-    @property
     def valid_data_dir(self) -> Path:
         return self.valid_corpus_step.output_dir
 
@@ -97,12 +213,7 @@ class TrainModelStep(OpusPocusStep):
 
     @property
     def vocab_path(self) -> Path:
-        vocab_dir = self.vocab_step.output_dir
-
-        # TODO: this should be fetched from the dependency in case that
-        # file naming changes in the future
-        vocab_path = Path(vocab_dir, f"model.{self.src_lang}-{self.tgt_lang}.spm")
-        return vocab_path  # noqa: RET504
+        return self.vocab_step.vocab_path
 
     @property
     def vocab_size(self) -> int:
@@ -125,81 +236,65 @@ class TrainModelStep(OpusPocusStep):
         return RunnerResources(gpus=1)
 
     def get_command_targets(self) -> List[Path]:
-        return [self.model_path]
+        return [Path(str(self.model_path) + ".DONE")]
 
     def command(self, target_file: Path) -> None:
-        model_path = target_file  # for better readability
-
         env = os.environ
         n_cpus = int(env[RunnerResources.get_env_name("cpus")])
         n_gpus = 0
         if RunnerResources.get_env_name("gpus") in env:
             n_gpus = int(env[RunnerResources.get_env_name("gpus")])
 
-        # Prepare the command
-        marian_path = Path(self.marian_dir, "bin", "marian")
-        cmd = [
-            str(marian_path),
+        trainer = [
+            f"{self.marian_dir}/build/marian",
+            "-t",
+            "stdin",
             "-c",
-            str(self.marian_config),
-            "--seed",
-            str(self.seed),
+            f"{self.marian_config_path}",
             "--data-threads",
-            str(n_cpus),
-            "--model",
-            str(model_path),
-            "--vocabs",
-            str(self.vocab_path),
-            str(self.vocab_path),
-            "--dim-vocabs",
-            str(self.vocab_size),
-            "--tempdir",
-            str(self.tmp_dir),
-            "--valid-translation-output",
-            f"{self.log_dir}/valid.out",
-            "--log-level",
-            "info",
-            "--log",
-            f"{self.log_dir}/train.log",
-            "--valid-log",
-            f"{self.log_dir}/valid.log",
+            f"{n_cpus}",
         ]
-
-        # Training data
-        # TODO: Data concatenation should be removed when opustrainer support
-        #       is added
-        train_paths = [Path(self.tmp_dir, f"train.{lang}.gz") for lang in self.languages]
-        if not all([p.exists() for p in train_paths]):  # noqa: C419
-            for lang, output_file in zip(self.languages, train_paths):
-                concat_files(
-                    [Path(self.input_dir, f"{dset}.{lang}.gz") for dset in self.train_datasets],
-                    output_file,
-                )
-        cmd += ["--train-sets"] + [str(p) for p in train_paths]
-
-        # Validation data
-        cmd += ["--valid-sets"] + [f"{self.valid_data_dir}/{self.valid_dataset}.{lang}.gz" for lang in self.languages]
 
         # GPU option
         if n_gpus:
-            cmd += ["--devices"] + [str(i) for i in range(n_gpus)]
+            trainer += ["--devices"] + [str(i) for i in range(n_gpus)]
         else:
-            cmd += ["--cpu-threads", str(n_cpus)]
+            trainer += ["--cpu-threads", str(n_cpus)]
 
         # Initial checkpoint option
         if self.model_init_path is not None:
-            cmd += ["--pretrained-model", str(self.model_init_path)]
+            trainer = ["--pretrained-model", self.model_init_path]
 
-        # Execute the command
-        proc = subprocess.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr, env=env, text=True)
+        # Prepare training datasets TSV files
+        for dset_path in self.opustrainer_dataset_paths:
+            if dset_path.exists():
+                continue
+            logger.info("Creating dataset %s...", dset_path)
+            dset = ".".join(dset_path.stem.split(".")[:-1])
+            in_files = [Path(self.train_corpus_step.output_dir, f"{dset}.{lang}.gz") for lang in self.languages]
+            paste_files(in_files, dset_path)
 
-        # Propagate the termination signal to the child process
-        def step_terminate_handler(signum, _):  # noqa: ANN001, ANN202
-            logger.debug("Received signal %i, gracefully terminating Marian child process...", signum)
-            proc.terminate()
-            err_msg = f"{self.step_label}.command received signal {signum}. Terminating..."
-            raise InterruptedError(err_msg)
+        # Prepare valid dataset TSV file
+        if not self.valid_dataset_path.exists():
+            logger.info("Creating dataset %s...", self.valid_dataset_path)
+            dset = ".".join(self.valid_dataset_path.stem.split(".")[:-1])
+            in_files = [Path(self.valid_corpus_step.output_dir, f"{dset}.{lang}.gz") for lang in self.languages]
+            paste_files(in_files, self.valid_dataset_path)
 
-        signal.signal(signal.SIGUSR1, step_terminate_handler)
-        signal.signal(signal.SIGTERM, step_terminate_handler)
-        subprocess_wait(proc)
+        args = argparse.Namespace(
+            **{
+                "config": str(self.opustrainer_config_path),
+                "state": None,
+                "sync": False,
+                "temporary_directory": str(self.tmp_dir),
+                "do_not_resume": False,
+                "shuffle": True,
+                "trainer": trainer,
+            }
+        )
+        rc = opustrainer_trainer.main(args)
+        if rc != 0:
+            err_msg = f"Opustrainer exited with non-zero return code ({rc})"
+            raise subprocess.SubprocessError(err_msg)
+
+        target_file.touch()  # touch target file so we know that the training finished

--- a/opuspocus/pipeline_steps/translate.py
+++ b/opuspocus/pipeline_steps/translate.py
@@ -115,7 +115,7 @@ class TranslateCorpusStep(CorpusStep):
         input_file = self.infer_input(target_file)
 
         # Prepare the command
-        marian_path = Path(self.marian_dir, "bin", "marian-decoder")
+        marian_path = Path(self.marian_dir, "build", "marian-decoder")
         cmd = [
             str(marian_path),
             "-c",

--- a/opuspocus/pipelines/opuspocus_pipeline.py
+++ b/opuspocus/pipelines/opuspocus_pipeline.py
@@ -199,7 +199,15 @@ class OpusPocusPipeline:
         raise ValueError(err_msg)
 
     def get_dependants(self, step: OpusPocusStep) -> List[OpusPocusStep]:
-        return [s for s in self.steps if any(dep.step_label == step.step_label for dep in s.dependencies.values())]
+        logger.info("dep: %s", step.step_label)
+        ret = []
+        for s in self.steps:
+            for dep in s.dependencies.values():
+                if dep is None:
+                    continue
+                if dep.step_label == step.step_label:
+                    ret.append(s)
+        return ret
 
     def __eq__(self, other: "OpusPocusPipeline") -> bool:
         """Object comparison logic."""

--- a/opuspocus/pipelines/opuspocus_pipeline.py
+++ b/opuspocus/pipelines/opuspocus_pipeline.py
@@ -185,9 +185,8 @@ class OpusPocusPipeline:
             for target in targets:
                 target_step = self._get_step(target)
                 if target_step is None:
-                    raise ValueError(
-                        f"Unknown pipeline step (label: {target}) requested as a target."
-                    )
+                    err_msg = f"Unknown pipeline step (label: {target}) requested as a target."
+                    raise ValueError(err_msg)
                 output_targets.append(target_step)
             return output_targets
         if self.default_targets is not None:

--- a/opuspocus/pipelines/opuspocus_pipeline.py
+++ b/opuspocus/pipelines/opuspocus_pipeline.py
@@ -172,9 +172,24 @@ class OpusPocusPipeline:
             v.traceback_step(level=0, full=full)
             print()  # noqa: T201
 
+    def _get_step(self, step_label: str) -> Optional[OpusPocusStep]:
+        output = [s for s in self.steps if s.step_label == step_label]
+        assert len(output) <= 1
+        if output:
+            return output[0]
+        return None
+
     def get_targets(self, targets: Optional[List[str]] = None) -> List[OpusPocusStep]:
         if targets is not None:
-            return targets
+            output_targets = []
+            for target in targets:
+                target_step = self._get_step(target)
+                if target_step is None:
+                    raise ValueError(
+                        f"Unknown pipeline step (label: {target}) requested as a target."
+                    )
+                output_targets.append(target_step)
+            return output_targets
         if self.default_targets is not None:
             logger.info("No target steps were specified. Using default targets.")
             return self.default_targets

--- a/opuspocus/runners/bash.py
+++ b/opuspocus/runners/bash.py
@@ -129,6 +129,13 @@ class BashRunner(OpusPocusRunner):
                 err_msg = f"Process {pid} exited with non-zero value."
                 raise subprocess.SubprocessError(err_msg)
 
+    def is_task_running(self, task_info: TaskInfo) -> bool:
+        pid = task_info["id"]
+        proc = self._get_process(task_info)
+        if proc is None:
+            return False
+        return True
+
     def _get_process(self, task_info: BashTaskInfo) -> Optional[Process]:
         """TODO"""
         try:

--- a/opuspocus/runners/bash.py
+++ b/opuspocus/runners/bash.py
@@ -114,12 +114,14 @@ class BashRunner(OpusPocusRunner):
         if proc is not None:
             proc.send_signal(signal)
 
-    def wait_for_single_task(self, task_info: BashTaskInfo) -> None:
+    def wait_for_single_task(self, task_info: BashTaskInfo, *, ignore_returncode: bool = False) -> None:
         pid = task_info["id"]
         proc = self._get_process(task_info)
         if proc is None:
             return
         gone, _ = wait_procs([proc])
+        if ignore_returncode:
+            return
         for p in gone:
             if p.returncode:
                 if task_info["file_path"] is not None:
@@ -130,11 +132,7 @@ class BashRunner(OpusPocusRunner):
                 raise subprocess.SubprocessError(err_msg)
 
     def is_task_running(self, task_info: TaskInfo) -> bool:
-        pid = task_info["id"]
-        proc = self._get_process(task_info)
-        if proc is None:
-            return False
-        return True
+        return self._get_process(task_info) is not None
 
     def _get_process(self, task_info: BashTaskInfo) -> Optional[Process]:
         """TODO"""

--- a/opuspocus/runners/opuspocus_runner.py
+++ b/opuspocus/runners/opuspocus_runner.py
@@ -1,6 +1,7 @@
 import inspect
 import logging
 import signal
+import time
 from argparse import ArgumentParser
 from pathlib import Path
 from typing import Any, Dict, List, Optional, get_type_hints
@@ -13,6 +14,8 @@ from opuspocus.pipelines import OpusPocusPipeline
 from opuspocus.utils import RunnerResources
 
 logger = logging.getLogger(__name__)
+
+SLEEP_TIME = 0.5
 
 
 class TaskInfo(TypedDict):
@@ -188,31 +191,43 @@ class OpusPocusRunner:
         # NOTE(varisd): we set the state to SUBMITTED before actual submission to avoid possible race conditions
         step.state = StepState.SUBMITTED
         try:
+            timestamp = time.time()
             task_info = self.submit_task(
                 cmd_path=cmd_path,
                 target_file=None,
                 dependencies=[dep["main_task"] for dep in dep_sub_info_list],
                 step_resources=self.get_resources(step),
-                stdout_file=Path(step.log_dir, f"{self.runner}.main.out"),
-                stderr_file=Path(step.log_dir, f"{self.runner}.main.err"),
+                stdout_file=Path(step.log_dir, f"{self.runner}.main.{timestamp}.out"),
+                stderr_file=Path(step.log_dir, f"{self.runner}.main.{timestamp}.err"),
             )
-        except Exception:
+        except Exception as err:
             step.state = StepState.FAILED
+            logger.exception("Task submission in runner.submit_step raised the following error:\n%s", err.message)
             raise
 
         sub_info = SubmissionInfo(runner=self.runner, main_task=task_info, subtasks=[])
         self.save_submission_info(step, sub_info)
         return sub_info
 
-    def resubmit_step(self, step: OpusPocusStep, *, keep_finished: bool = False) -> None:
+    def resubmit_step(self, step: OpusPocusStep, *, keep_finished: bool = False) -> SubmissionInfo:
         """TODO"""
         sub_info = self.load_submission_info(step)
         if keep_finished:
             self.send_signal(sub_info["main_task"], signal.SIGUSR1)
         else:
             self.send_signal(sub_info["main_task"], signal.SIGUSR2)
-        self.wait_for_single_task(sub_info["main_task"])  # wait until the original task resubmits and finishes
+        while step.state != StepState.RUNNING:
+            time.sleep(SLEEP_TIME)
         return self.load_submission_info(step)
+
+    def update_dependants(
+        self,
+        step: OpusPocusStep,
+        remove_task_list: Optional[List[TaskInfo]] = None,
+        add_task_list: Optional[List[TaskInfo]] = None,
+    ) -> None:
+        """TODO"""
+        raise NotImplementedError()
 
     def submit_task(
         self,
@@ -234,11 +249,13 @@ class OpusPocusRunner:
         """TODO"""
         self.send_signal(task_info, signal.SIGTERM)
 
-    def wait_for_tasks(self, task_info_list: Optional[List[TaskInfo]] = None) -> None:
+    def wait_for_tasks(
+        self, task_info_list: Optional[List[TaskInfo]] = None, *, ignore_returncode: bool = False
+    ) -> None:
         for task_info in task_info_list:
-            self.wait_for_single_task(task_info)
+            self.wait_for_single_task(task_info, ignore_returncode=ignore_returncode)
 
-    def wait_for_single_task(self, task_info: TaskInfo) -> None:
+    def wait_for_single_task(self, task_info: TaskInfo, *, ignore_returncode: bool = False) -> None:
         raise NotImplementedError()
 
     def is_task_running(self, task_info: TaskInfo) -> bool:

--- a/opuspocus/runners/opuspocus_runner.py
+++ b/opuspocus/runners/opuspocus_runner.py
@@ -130,7 +130,7 @@ class OpusPocusRunner:
     def run_pipeline(
         self,
         pipeline: OpusPocusPipeline,
-        targets: List[str],
+        targets: Optional[List[OpusPocusStep]] = None,
         *,
         keep_finished: bool = False,
     ) -> None:
@@ -239,6 +239,9 @@ class OpusPocusRunner:
             self.wait_for_single_task(task_info)
 
     def wait_for_single_task(self, task_info: TaskInfo) -> None:
+        raise NotImplementedError()
+
+    def is_task_running(self, task_info: TaskInfo) -> bool:
         raise NotImplementedError()
 
     def save_submission_info(self, step: OpusPocusStep, sub_info: SubmissionInfo) -> None:

--- a/opuspocus/runners/slurm.py
+++ b/opuspocus/runners/slurm.py
@@ -104,7 +104,6 @@ class SlurmRunner(OpusPocusRunner):
         logger.info("Submitted sbatch command, jobid: %i", jid)
         logger.debug("sbatch output: '%s'", cmd_out)
 
-        logger.debug("Job info:\n%s", "".join(self._get_sacct_info(task_info)))
         return task_info
 
     def _update_dependants(self, step: OpusPocusStep, task_info: SlurmTaskInfo) -> None:
@@ -149,6 +148,7 @@ class SlurmRunner(OpusPocusRunner):
 
     def wait_for_single_task(self, task_info: SlurmTaskInfo) -> None:
         """TODO"""
+        time.sleep(SLEEP_TIME)  # NOTE(varisd): workaround to give sbatch time to properly submit the job
         while self.is_task_running(task_info):
             time.sleep(SLEEP_TIME)
         status = self._get_job_status(task_info)

--- a/opuspocus/tools/opustrainer_trainer.py
+++ b/opuspocus/tools/opustrainer_trainer.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""A translation model trainer. It feeds marian different sets of datasets with different thresholds
+for different stages of the training. Data is uncompressed and TSV formatted src\ttrg
+"""
+import argparse
+import os
+import signal
+import subprocess
+import sys
+import yaml
+
+from opustrainer.trainer import (
+    AsyncDatasetReader,
+    CurriculumLoader,
+    DatasetReader,
+    StateTracker,
+    Trainer,
+    ignore_sigint
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Feeds marian tsv data for training.")
+    parser.add_argument("--config", "-c", required=True, type=str, help="YAML configuration input.")
+    parser.add_argument("--state", "-s", type=str, help="YAML state file, defaults to ${CONFIG}.state.")
+    parser.add_argument("--sync", action="store_true", help="Do not shuffle async.")
+    parser.add_argument(
+        "--temporary-directory", "-T", default=None, type=str,
+        help="Temporary dir, used for shuffling and tracking state."
+    )
+    parser.add_argument(
+        "--do-not-resume", "-d", action="store_true",
+        help="Do not resume from the previous training state."
+    )
+    parser.add_argument(
+        "--no-shuffle", "-n", action="store_false", dest="shuffle",
+        help="Do not shuffle, for debugging."
+    )
+    parser.add_argument(
+        "trainer", type=str, nargs=argparse.REMAINDER,
+        help="Trainer program that gets fed the input. If empty it is read from config."
+    )
+
+    return parser.parse_args()
+
+def main(args: argparse.Namespace) -> int:
+    with open(args.config, 'r', encoding='utf-8') as fh:
+        config = yaml.safe_load(fh)
+
+    curriculum = CurriculumLoader().load(config, basepath=os.path.dirname(args.config))
+
+    # Quick cheap check that all files exist before we begin training
+    for dataset in curriculum.datasets.values():
+        missing_files = {file for file in dataset.files if not os.path.exists(file)}
+        if missing_files:
+            raise ValueError(f"Dataset '{dataset.name}' is missing files: {missing_files}")
+
+    trainer = Trainer(curriculum, reader=DatasetReader if args.sync else AsyncDatasetReader, tmpdir=args.temporary_directory, shuffle=args.shuffle)
+
+    state_tracker = StateTracker(args.state or f'{args.config}.state', restore=not args.do_not_resume)
+
+    # Make trainer listen to `kill -SIGUSR1 $PID` to print dataset progress
+    signal.signal(signal.SIGUSR1, lambda signum, handler: print_state(trainer.state(), sys.stderr))
+
+    print(args.trainer)
+    model_trainer = subprocess.Popen(
+        args.trainer or config['trainer'],
+        stdin=subprocess.PIPE,
+        encoding="utf-8",
+        preexec_fn=ignore_sigint) # ignore_sigint makes marian ignore Ctrl-C. We'll stop it from here.
+
+    assert model_trainer.stdin is not None
+
+    # TODO: This logic looks complicated, should be able to do this simpler. Three scenarios:
+    #   1. ctrl-c is pressed and trainer is told this is the end of the training data
+    #   2. ctrl-c is pressed and trainer has much training data in its buffers, ctrl-c needs to be
+    #      pressed again to tell trainer to really terminate. Just closing its stdin and waiting for
+    #      it to notice takes too long
+    #   3. trainer decides it has read enough and will train no longer. This is the BrokenPipeError
+    #      scenario. We don't need to deal with multiple levels of terminating the trainer because
+    #      the trainer is already dead at this point.
+    try:
+        try:
+            for batch in state_tracker.run(trainer):
+                model_trainer.stdin.writelines(batch)
+        except KeyboardInterrupt:
+            print("[Trainer] Ctrl-c pressed, stopping training")
+
+        # Levels of waiting for the trainer. This is reached either because we ran out of batches
+        # or because ctrl-c was pressed. Pressing ctrl-c more advances to next level of aggressiveness.
+        for stage in ['exit', 'terminate', 'kill']:
+            try:
+                if stage == 'exit':
+                    model_trainer.stdin.close()
+                elif stage == 'terminate':
+                    model_trainer.terminate()
+                else:
+                    model_trainer.kill()
+
+                print(f"[Trainer] waiting for trainer to {stage}. Press ctrl-c to be more aggressive")
+                return model_trainer.wait() # blocking
+            except KeyboardInterrupt:
+                continue
+    except BrokenPipeError:
+        # BrokenPipeError is thrown by writelines() or close() and indicates that the child trainer
+        # process is no more. We can safely retrieve its return code and exit with that, it should
+        # not block at this point.
+        print("[Trainer] trainer stopped reading input")
+        sys.exit(model_trainer.wait())
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(parse_args()))

--- a/opuspocus_cli/run.py
+++ b/opuspocus_cli/run.py
@@ -21,7 +21,7 @@ def main(args: Namespace) -> int:
     """
     pipeline = load_pipeline(args)
     runner = build_runner(args.runner, args.pipeline_dir, args)
-    runner.run_pipeline(pipeline, targets=pipeline.get_targets(args.targets))
+    runner.run_pipeline(pipeline, targets=args.targets)
     return 0
 
 

--- a/scripts/bash_runner_submit.py
+++ b/scripts/bash_runner_submit.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import os
 import signal
 import subprocess
 import sys
@@ -7,6 +8,7 @@ import time
 import psutil
 
 FILE = __file__.split("/")[-1]
+MAX_ARGS = 3
 
 
 def raise_nonzero_error(arguments, pid):  # noqa: ANN001, ANN201 fixit
@@ -15,9 +17,12 @@ def raise_nonzero_error(arguments, pid):  # noqa: ANN001, ANN201 fixit
 
 def main(argv):  # noqa: ANN001, ANN201 fixit
     """Wrapper for executing Bash commands that have process dependencies."""
+    print(  # noqa: T201
+        f"bash_runner_submit.py: Script pid: {os.getpid()}", file=sys.stderr
+    )
     cmd_path = argv[1]
     proc_ids = []
-    if len(argv) == 3 and argv[2]:
+    if len(argv) == MAX_ARGS and argv[2]:
         proc_ids = [int(proc) for proc in argv[2].split(" ")]
 
     procs = []

--- a/scripts/bash_runner_submit.py
+++ b/scripts/bash_runner_submit.py
@@ -17,7 +17,7 @@ def main(argv):  # noqa: ANN001, ANN201 fixit
     """Wrapper for executing Bash commands that have process dependencies."""
     cmd_path = argv[1]
     proc_ids = []
-    if argv[2]:
+    if len(argv) == 3 and argv[2]:
         proc_ids = [int(proc) for proc in argv[2].split(" ")]
 
     procs = []

--- a/tests/fixtures/configs.py
+++ b/tests/fixtures/configs.py
@@ -45,7 +45,7 @@ def marian_tiny_config_file(config_dir):
 @pytest.fixture(scope="session")
 def opustrainer_tiny_config_file(config_dir):  # noqa: ARG001, PT004
     """Prepares small-data config for opustrainer training."""
-    # TODO(varisd): implement this when OpusTrainer support is added.
+    # TODO(varisd): implement this for testing scenarios where OpusTrainer config is provided
     pass
 
 

--- a/tests/fixtures/pipelines.py
+++ b/tests/fixtures/pipelines.py
@@ -57,7 +57,7 @@ def pipeline_preprocess_tiny_inited(
 def pipeline_preprocess_tiny_done(pipeline_preprocess_tiny_inited):
     """Run mock dataset preprocessing pipeline."""
     runner = DebugRunner("debug", pipeline_preprocess_tiny_inited.pipeline_dir)
-    runner.run_pipeline(pipeline_preprocess_tiny_inited, pipeline_preprocess_tiny_inited.get_targets())
+    runner.run_pipeline(pipeline_preprocess_tiny_inited)
     return pipeline_preprocess_tiny_inited
 
 
@@ -84,8 +84,5 @@ def pipeline_train_tiny_inited(
 def pipeline_train_tiny_done(pipeline_train_tiny_inited):
     """Run mock training pipeline."""
     runner = DebugRunner("debug", pipeline_train_tiny_inited.pipeline_dir)
-    runner.run_pipeline(
-        pipeline_train_tiny_inited,
-        pipeline_train_tiny_inited.get_targets(),
-    )
+    runner.run_pipeline(pipeline_train_tiny_inited)
     return pipeline_train_tiny_inited

--- a/tests/fixtures/steps.py
+++ b/tests/fixtures/steps.py
@@ -10,7 +10,7 @@ from opuspocus.pipeline_steps import OpusPocusStep, build_step, register_step
 
 @register_step("foo")
 class FooStep(OpusPocusStep):
-    SLEEP_TIME = 15
+    SLEEP_TIME = 10
 
     def __init__(
         self, step: str, step_label: str, pipeline_dir: Path, dependency_step: Optional["FooStep"] = None

--- a/tests/opuspocus/pipeline_steps/conftest.py
+++ b/tests/opuspocus/pipeline_steps/conftest.py
@@ -71,8 +71,10 @@ def train_data_parallel_tiny_model_step_inited(
             "opustrainer_config": opustrainer_tiny_config_file,
             "train_corpus_step": train_data_parallel_tiny_raw_step_inited,
             "valid_corpus_step": train_data_parallel_tiny_raw_step_inited,
-            "train_category": train_data_parallel_tiny_raw_step_inited.categories[0],
+            "train_categories": [train_data_parallel_tiny_raw_step_inited.categories[0]],
+            "train_category_ratios": [1.0],
             "valid_dataset": train_data_parallel_tiny_raw_step_inited.dataset_list[0],
+            "max_epochs": 1
         },
     )
     step.init_step()

--- a/tests/opuspocus/pipeline_steps/conftest.py
+++ b/tests/opuspocus/pipeline_steps/conftest.py
@@ -76,7 +76,7 @@ def train_data_parallel_tiny_model_step_inited(
             "train_categories": [train_data_parallel_tiny_raw_step_inited.categories[0]],
             "train_category_ratios": [1.0],
             "valid_dataset": train_data_parallel_tiny_raw_step_inited.dataset_list[0],
-            "max_epochs": 1
+            "max_epochs": 1,
         },
     )
     step.init_step()

--- a/tests/opuspocus/pipeline_steps/conftest.py
+++ b/tests/opuspocus/pipeline_steps/conftest.py
@@ -58,6 +58,8 @@ def train_data_parallel_tiny_model_step_inited(
 ):
     """Create the mock train_model step."""
     marian_dir = train_data_parallel_tiny_vocab_step_inited.marian_dir
+    if "cpu" in str(marian_dir):
+        pytest.skip(reason=("Model training is not supported on CPU-only machines."))
     step = build_step(
         step="train_model",
         step_label=f"train_model.{marian_dir}.test",

--- a/tests/opuspocus/pipeline_steps/test_evaluate.py
+++ b/tests/opuspocus/pipeline_steps/test_evaluate.py
@@ -25,7 +25,7 @@ def evaluate_step_inited(request, train_data_parallel_tiny_raw_step_inited):
     return step
 
 
-def test_evaluate_step_unknown_metric(train_data_parallel_tiny_raw_step_inited):
+def test_evaluate_step_unknown_metric_fail(train_data_parallel_tiny_raw_step_inited):
     """Step construction fails when presented with unknown metric."""
     with pytest.raises(ValueError):  # noqa: PT011
         build_step(

--- a/tests/opuspocus/pipeline_steps/test_merge.py
+++ b/tests/opuspocus/pipeline_steps/test_merge.py
@@ -1,0 +1,69 @@
+import pytest
+from pathlib import Path
+
+from opuspocus.pipeline_steps import StepState, build_step
+from opuspocus.pipeline_steps.merge import MergeCorpusStep
+from opuspocus.runners.debug import DebugRunner
+
+
+@pytest.fixture(scope="function", params=[True, False])  # noqa: PT003
+def merge_step_inited(request, train_data_parallel_tiny_raw_step_inited):
+    """Create and initialize the merge step."""
+    step = build_step(
+        step="merge",
+        step_label=f"merge.{request.param}.test",
+        pipeline_dir=train_data_parallel_tiny_raw_step_inited.pipeline_dir,
+        **{
+            "src_lang": train_data_parallel_tiny_raw_step_inited.src_lang,
+            "tgt_lang": train_data_parallel_tiny_raw_step_inited.tgt_lang,
+            "previous_corpus_step": train_data_parallel_tiny_raw_step_inited,
+            "previous_corpus_label": "previous",
+            "other_corpus_step": train_data_parallel_tiny_raw_step_inited,
+            "other_corpus_label": "other",
+            "merge_categories": request.param,
+        },
+    )
+    step.init_step()
+    return step
+
+
+def test_merge_step_inited(merge_step_inited):
+    """Test whether the step was initialized successfully."""
+    assert merge_step_inited.state == StepState.INITED
+
+
+@pytest.fixture(scope="function")  # noqa: PT003
+def merge_step_done(merge_step_inited):
+    """Execute the merge step."""
+    runner = DebugRunner("debug", merge_step_inited.pipeline_dir)
+    runner.submit_step(merge_step_inited)
+    return merge_step_inited
+
+
+def test_merge_step_done(merge_step_done):
+    """Test whether the step execution finished successfully."""
+    assert merge_step_done.state == StepState.DONE
+
+
+def test_datasets_merged(merge_step_done):
+    dset_set = set(merge_step_done.prev_corpus_step.dataset_list + merge_step_done.other_corpus_step.dataset_list)
+    for dataset in merge_step_done.dataset_list:
+        dataset = ".".join(dataset.split(".")[1:])
+        assert dataset in dset_set
+
+
+def test_dataset_files_merged(merge_step_done):
+    for dataset in merge_step_done.dataset_list:
+        for lang in merge_step_done.languages:
+            dset_path = Path(merge_step_done.output_dir, f"{dataset}.{lang}.gz")
+            assert dset_path.exists()
+
+
+def test_categories_merged(merge_step_done):
+    categories_set = set(merge_step_done.prev_corpus_step.categories + merge_step_done.other_corpus_step.categories)
+    for cat in merge_step_done.categories:
+        if merge_step_done.merge_categories:
+            assert cat in categories_set
+        else:
+            label, orig_cat = cat.split(".")
+            assert orig_cat in merge_step_done.dependencies[f"{label}_corpus_step"].categories

--- a/tests/opuspocus/pipeline_steps/test_merge.py
+++ b/tests/opuspocus/pipeline_steps/test_merge.py
@@ -1,8 +1,8 @@
-import pytest
 from pathlib import Path
 
+import pytest
+
 from opuspocus.pipeline_steps import StepState, build_step
-from opuspocus.pipeline_steps.merge import MergeCorpusStep
 from opuspocus.runners.debug import DebugRunner
 
 
@@ -48,8 +48,8 @@ def test_merge_step_done(merge_step_done):
 def test_datasets_merged(merge_step_done):
     dset_set = set(merge_step_done.prev_corpus_step.dataset_list + merge_step_done.other_corpus_step.dataset_list)
     for dataset in merge_step_done.dataset_list:
-        dataset = ".".join(dataset.split(".")[1:])
-        assert dataset in dset_set
+        dataset_orig = ".".join(dataset.split(".")[1:])
+        assert dataset_orig in dset_set
 
 
 def test_dataset_files_merged(merge_step_done):

--- a/tests/opuspocus/pipeline_steps/test_train_model.py
+++ b/tests/opuspocus/pipeline_steps/test_train_model.py
@@ -40,7 +40,7 @@ def test_train_model_step_done(train_model_step_done):
         {"train_categories": ["clean"], "train_category_ratios": [0.1, 0.9]},
         {"train_categories": ["clean"], "train_category_ratios": [0.9]},
         {"train_categories": ["foo", "bar"], "train_category_ratios": [0.9, 0.1]},
-        {"train_categories": ["clean"], "train_category_ratios": [1.], "max_epochs": -1}
+        {"train_categories": ["clean"], "train_category_ratios": [1.0], "max_epochs": -1},
     ],
 )
 def test_invalid_parameters_fail(params_invalid, train_data_parallel_tiny_model_step_inited):
@@ -54,6 +54,6 @@ def test_invalid_parameters_fail(params_invalid, train_data_parallel_tiny_model_
     del param_dict["step"]
     del param_dict["step_label"]
     del param_dict["pipeline_dir"]
-    with pytest.raises(ValueError):  # noqa: PT011
+    with pytest.raises(ValueError):  # noqa: PT011, PT012
         step = build_step(step="train_model", step_label="train_model.fail", pipeline_dir=pipeline_dir, **param_dict)
         step.init_step()

--- a/tests/opuspocus/pipelines/test_pipelines.py
+++ b/tests/opuspocus/pipelines/test_pipelines.py
@@ -72,3 +72,15 @@ def test_pipeline_class_init_default_targets(pipeline_preprocess_tiny_config_fil
     assert len(config_targets) == len(pipeline_preprocess_tiny_inited.default_targets)
     for target in pipeline_preprocess_tiny_inited.default_targets:
         assert target.step_label in config_targets
+
+
+def test_get_pipeline_targets(pipeline_preprocess_tiny_config_file, pipeline_preprocess_tiny_inited):
+    config = PipelineConfig.load(pipeline_preprocess_tiny_config_file)
+    config_targets = config["pipeline"]["default_targets"]
+    for target in pipeline_preprocess_tiny_inited.get_targets(config_targets):
+        assert target in pipeline_preprocess_tiny_inited.default_targets
+
+
+def test_get_unknown_pipeline_target_fail(pipeline_preprocess_tiny_inited):
+    with pytest.raises(ValueError):
+        pipeline_preprocess_tiny_inited.get_targets("foo")

--- a/tests/opuspocus/pipelines/test_pipelines.py
+++ b/tests/opuspocus/pipelines/test_pipelines.py
@@ -82,5 +82,5 @@ def test_get_pipeline_targets(pipeline_preprocess_tiny_config_file, pipeline_pre
 
 
 def test_get_unknown_pipeline_target_fail(pipeline_preprocess_tiny_inited):
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError):  # noqa: PT011
         pipeline_preprocess_tiny_inited.get_targets("foo")

--- a/tests/opuspocus/runners/test_runners.py
+++ b/tests/opuspocus/runners/test_runners.py
@@ -1,7 +1,7 @@
-import time
-from pathlib import Path
-
 import pytest
+import time
+import subprocess
+from pathlib import Path
 
 from opuspocus.pipeline_steps import StepState
 from opuspocus.runners import OpusPocusRunner, load_runner
@@ -83,7 +83,8 @@ def test_cancel_main_task(foo_runner_for_step_submit, foo_step_inited):
     time.sleep(SLEEP_TIME)
 
     foo_runner_for_step_submit.cancel_task(sub_info["main_task"])
-    time.sleep(SLEEP_TIME)
+    with pytest.raises(subprocess.SubprocessError):
+        foo_runner_for_step_submit.wait_for_single_task(sub_info["main_task"])
 
     assert foo_step_inited.state == StepState.FAILED
     for t_info in sub_info["subtasks"]:

--- a/tests/opuspocus/runners/test_runners.py
+++ b/tests/opuspocus/runners/test_runners.py
@@ -37,14 +37,14 @@ def test_load_runner_method(foo_runner):
 
 
 def test_run_pipeline(foo_runner, foo_pipeline_inited):
-    foo_runner.run_pipeline(foo_pipeline_inited, foo_pipeline_inited.get_targets())
+    foo_runner.run_pipeline(foo_pipeline_inited)
     for step in foo_pipeline_inited.steps:
         if foo_runner.runner == "bash":
             assert step.state in (StepState.SUBMITTED, StepState.RUNNING)
 
 
 def test_stop_pipeline(foo_runner, foo_pipeline_inited):
-    foo_runner.run_pipeline(foo_pipeline_inited, foo_pipeline_inited.get_targets())
+    foo_runner.run_pipeline(foo_pipeline_inited)
     time.sleep(SLEEP_TIME)
 
     foo_runner.stop_pipeline(foo_pipeline_inited)
@@ -53,7 +53,7 @@ def test_stop_pipeline(foo_runner, foo_pipeline_inited):
 
 
 def test_stop_pipeline_with_nonmatching_runner_fail(foo_runner, foo_pipeline_inited):
-    foo_runner.run_pipeline(foo_pipeline_inited, foo_pipeline_inited.get_targets())
+    foo_runner.run_pipeline(foo_pipeline_inited)
     foo_runner.runner = "foobar"
     with pytest.raises(ValueError):  # noqa: PT011
         foo_runner.stop_pipeline(foo_pipeline_inited)


### PR DESCRIPTION
- TrainModelSteps now uses OpusTrainer instead of directly calling Marian.
- MergeStep was adjusted to be configurable to properly prepare authentic and synthetic datasets for BT training
- Slurm and Bash runner tests are now passing, including step cancellation and resubmision. Wider test coverage still might be needed.