### PR TITLE
Config overhaul (part 2)

### DIFF
--- a/opuspocus/options.py
+++ b/opuspocus/options.py
@@ -77,13 +77,6 @@ def parse_run_args(argv: Sequence[str]) -> argparse.Namespace:
         default=argparse.SUPPRESS,
         help="Runner used for pipeline execution manipulation {" + ",".join(RUNNER_REGISTRY.keys()) + "}",
     )
-    parser.add_argument(
-        "--targets",
-        type=str,
-        nargs="+",
-        default=None,
-        help="List of step labels to be executed together with their dependencies.",
-    )
 
     args, unparsed = parser.parse_known_args(argv)
     RUNNER_REGISTRY[args.runner.runner].add_args(parser)
@@ -111,13 +104,6 @@ def parse_traceback_args(argv: Sequence[str]) -> argparse.Namespace:
     parser = OpusPocusParser(description=f"{GENERAL_DESCRIPTION}: Pipeline Graph Traceback")
 
     _add_general_arguments(parser, pipeline_dir_required=True)
-    parser.add_argument(
-        "--targets",
-        type=str,
-        nargs="+",
-        default=None,
-        help="Pipeline targets from which to traceback.",
-    )
     parser.add_argument(
         "--verbose",
         default=False,

--- a/opuspocus/options.py
+++ b/opuspocus/options.py
@@ -70,9 +70,9 @@ def parse_run_args(argv: Sequence[str]) -> argparse.Namespace:
     parser.add_argument(
         "--runner",
         type=str,
-        metavar="RUNNER",
         required=True,
         choices=RUNNER_REGISTRY.keys(),
+        dest="runner.runner",
         help="Runner used for pipeline execution manipulation {" + ",".join(RUNNER_REGISTRY.keys()) + "}",
     )
     parser.add_argument(

--- a/opuspocus/options.py
+++ b/opuspocus/options.py
@@ -1,7 +1,7 @@
 import argparse
 import logging
 import sys
-from typing import Any, List, Optional, Sequence
+from typing import Optional, Sequence
 
 from opuspocus.pipelines import OpusPocusPipeline
 from opuspocus.runners import RUNNER_REGISTRY
@@ -10,7 +10,6 @@ from opuspocus.utils import NestedAction, file_path
 logger = logging.getLogger(__name__)
 
 GENERAL_DESCRIPTION = "OpusPocus NLP Pipeline Manager"
-
 
 
 class OpusPocusParser(argparse.ArgumentParser):

--- a/opuspocus/options.py
+++ b/opuspocus/options.py
@@ -1,15 +1,16 @@
 import argparse
 import logging
 import sys
-from typing import Optional, Sequence
+from typing import Any, List, Optional, Sequence
 
 from opuspocus.pipelines import OpusPocusPipeline
 from opuspocus.runners import RUNNER_REGISTRY
-from opuspocus.utils import file_path
+from opuspocus.utils import NestedAction, file_path
 
 logger = logging.getLogger(__name__)
 
 GENERAL_DESCRIPTION = "OpusPocus NLP Pipeline Manager"
+
 
 
 class OpusPocusParser(argparse.ArgumentParser):
@@ -73,6 +74,8 @@ def parse_run_args(argv: Sequence[str]) -> argparse.Namespace:
         required=True,
         choices=RUNNER_REGISTRY.keys(),
         dest="runner.runner",
+        action=NestedAction,
+        default=argparse.SUPPRESS,
         help="Runner used for pipeline execution manipulation {" + ",".join(RUNNER_REGISTRY.keys()) + "}",
     )
     parser.add_argument(
@@ -84,7 +87,7 @@ def parse_run_args(argv: Sequence[str]) -> argparse.Namespace:
     )
 
     args, unparsed = parser.parse_known_args(argv)
-    RUNNER_REGISTRY[args.runner].add_args(parser)
+    RUNNER_REGISTRY[args.runner.runner].add_args(parser)
 
     return parser.parse_args(argv)
 

--- a/opuspocus/pipeline_steps/clean.py
+++ b/opuspocus/pipeline_steps/clean.py
@@ -12,7 +12,8 @@ from attrs import define, field
 
 from opuspocus.pipeline_steps import register_step
 from opuspocus.pipeline_steps.corpus_step import CorpusStep
-from opuspocus.utils import RunnerResources, cut_filestream
+from opuspocus.runner_resources import RunnerResources
+from opuspocus.utils import cut_filestream
 
 logger = logging.getLogger(__name__)
 

--- a/opuspocus/pipeline_steps/generate_vocab.py
+++ b/opuspocus/pipeline_steps/generate_vocab.py
@@ -12,8 +12,8 @@ from attrs import Attribute, define, field, validators
 from opuspocus.pipeline_steps import register_step
 from opuspocus.pipeline_steps.corpus_step import CorpusStep
 from opuspocus.pipeline_steps.opuspocus_step import OpusPocusStep
+from opuspocus.runner_resources import RunnerResources
 from opuspocus.utils import (
-    RunnerResources,
     concat_files,
     decompress_file,
     subprocess_wait,

--- a/opuspocus/pipeline_steps/opuspocus_step.py
+++ b/opuspocus/pipeline_steps/opuspocus_step.py
@@ -500,7 +500,11 @@ def main(argv):
             step.run_subtask(target_file)
         elif len(argv) == 1:
             # Main task
-            runner = load_runner(Namespace(**{{"pipeline_dir": Path("{self.pipeline_dir}")}}))
+            runner = load_runner(
+                Namespace(**{{
+                    "pipeline": Namespace(**{{"pipeline_dir": Path("{self.pipeline_dir}")}})
+                }})
+            )
             step.run_main_task(runner)
         else:
             ValueError("Wrong number of arguments.")

--- a/opuspocus/pipeline_steps/opuspocus_step.py
+++ b/opuspocus/pipeline_steps/opuspocus_step.py
@@ -474,6 +474,7 @@ class OpusPocusStep:
         """Create the contents of the step's executable file."""
         return f"""#!/usr/bin/env python3
 import sys
+from argparse import Namespace
 from pathlib import Path
 
 from opuspocus.runners import load_runner
@@ -490,7 +491,7 @@ def main(argv):
             step.run_subtask(target_file)
         elif len(argv) == 1:
             # Main task
-            runner = load_runner(Path("{self.pipeline_dir}"))
+            runner = load_runner(Namespace(**{{"pipeline_dir": Path("{self.pipeline_dir}")}}))
             step.run_main_task(runner)
         else:
             ValueError("Wrong number of arguments.")

--- a/opuspocus/pipeline_steps/opuspocus_step.py
+++ b/opuspocus/pipeline_steps/opuspocus_step.py
@@ -419,7 +419,7 @@ class OpusPocusStep:
                 cmd_path=self.cmd_path,
                 target_file=target_file,
                 dependencies=None,
-                step_resources=runner.get_resources(self),
+                task_resources=runner.get_resources(self),
                 stdout_file=Path(self.log_dir, f"{runner.runner}.{target_file.stem}.{timestamp}.out"),
                 stderr_file=Path(self.log_dir, f"{runner.runner}.{target_file.stem}.{timestamp}.err"),
             )

--- a/opuspocus/pipeline_steps/opuspocus_step.py
+++ b/opuspocus/pipeline_steps/opuspocus_step.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import yaml
-from attrs import asdict, define, field, fields
+from attrs import asdict, define, field, fields, validators
 
 from opuspocus.runner_resources import RunnerResources
 from opuspocus.utils import clean_dir, print_indented
@@ -38,6 +38,9 @@ class OpusPocusStep:
     pipeline_dir: Path = field(
         converter=Path, eq=False
     )  # enables comparing pipelines/steps from different pipeline dirs
+    runner_resources: RunnerResources = field(
+        validator=validators.optional(validators.instance_of(RunnerResources)), default=None
+    )
 
     _cmd_filename = "step.command"
     _dependency_filename = "step.dependencies"
@@ -57,6 +60,9 @@ class OpusPocusStep:
         Returns:
             An instance of the specified pipeline class.
         """
+        if "runner_resources" in kwargs:
+            kwargs["runner_resources"] = RunnerResources(**kwargs["runner_resources"])
+
         return cls(step=step, step_label=step_label, pipeline_dir=pipeline_dir, **kwargs)
 
     @classmethod
@@ -543,8 +549,3 @@ if __name__ == "__main__":
                 print_indented("+ None", level + 1)
                 continue
             dep.print_traceback(level + 1, full=full)
-
-    @property
-    def default_resources(self) -> RunnerResources:
-        """Definition of default runner resources for a specific step."""
-        return RunnerResources()

--- a/opuspocus/pipeline_steps/opuspocus_step.py
+++ b/opuspocus/pipeline_steps/opuspocus_step.py
@@ -60,7 +60,7 @@ class OpusPocusStep:
         Returns:
             An instance of the specified pipeline class.
         """
-        if "runner_resources" in kwargs:
+        if "runner_resources" in kwargs and kwargs["runner_resources"] is not None:
             kwargs["runner_resources"] = RunnerResources(**kwargs["runner_resources"])
 
         return cls(step=step, step_label=step_label, pipeline_dir=pipeline_dir, **kwargs)
@@ -149,6 +149,8 @@ class OpusPocusStep:
                     param_dict[attr] = value["step_label"]
             elif isinstance(value, Path):
                 param_dict[attr] = str(value)
+            elif isinstance(value, RunnerResources):
+                param_dict[attr] = value.resource_dict
             elif isinstance(value, (list, tuple)) and any(isinstance(v, Path) for v in value):
                 param_dict[attr] = [str(v) for v in value]
             else:

--- a/opuspocus/pipeline_steps/opuspocus_step.py
+++ b/opuspocus/pipeline_steps/opuspocus_step.py
@@ -10,7 +10,8 @@ from typing import Any, Dict, List, Optional
 import yaml
 from attrs import asdict, define, field, fields
 
-from opuspocus.utils import RunnerResources, clean_dir, print_indented
+from opuspocus.runner_resources import RunnerResources
+from opuspocus.utils import clean_dir, print_indented
 
 logger = logging.getLogger(__name__)
 

--- a/opuspocus/pipeline_steps/train_model.py
+++ b/opuspocus/pipeline_steps/train_model.py
@@ -44,8 +44,7 @@ class TrainModelStep(OpusPocusStep):
     valid_dataset: str = field(default="flores200.dev")
 
     runner_resources: RunnerResources = field(
-        validator=validators.instance_of(RunnerResources),
-        default=RunnerResources(gpus=1)
+        validator=validators.instance_of(RunnerResources), default=RunnerResources(gpus=1)
     )
 
     _opustrainer_config_file = "opustrainer.config.yml"

--- a/opuspocus/pipeline_steps/train_model.py
+++ b/opuspocus/pipeline_steps/train_model.py
@@ -13,8 +13,9 @@ from opuspocus.pipeline_steps import register_step
 from opuspocus.pipeline_steps.corpus_step import CorpusStep
 from opuspocus.pipeline_steps.generate_vocab import GenerateVocabStep
 from opuspocus.pipeline_steps.opuspocus_step import OpusPocusStep
+from opuspocus.runner_resources import RunnerResources
 from opuspocus.tools import opustrainer_trainer
-from opuspocus.utils import RunnerResources, paste_files
+from opuspocus.utils import paste_files
 
 logger = logging.getLogger(__name__)
 

--- a/opuspocus/pipeline_steps/train_model.py
+++ b/opuspocus/pipeline_steps/train_model.py
@@ -43,6 +43,11 @@ class TrainModelStep(OpusPocusStep):
     train_modifiers: List[Dict[str, Any]] = field(default=Factory(lambda: [{"UpperCase": 0.01}, {"TitleCase": 0.01}]))
     valid_dataset: str = field(default="flores200.dev")
 
+    runner_resources: RunnerResources = field(
+        validator=validators.instance_of(RunnerResources),
+        default=RunnerResources(gpus=1)
+    )
+
     _opustrainer_config_file = "opustrainer.config.yml"
     _marian_config_file = "marian.config.yml"
 
@@ -340,7 +345,3 @@ class TrainModelStep(OpusPocusStep):
             raise subprocess.SubprocessError(err_msg)
 
         target_file.touch()  # touch target file so we know that the training finished
-
-    @property
-    def default_resources(self) -> RunnerResources:
-        return RunnerResources(gpus=1, mem="40g")

--- a/opuspocus/pipeline_steps/translate.py
+++ b/opuspocus/pipeline_steps/translate.py
@@ -12,7 +12,8 @@ from attrs import Attribute, define, field, validators
 from opuspocus.pipeline_steps import register_step
 from opuspocus.pipeline_steps.corpus_step import CorpusStep
 from opuspocus.pipeline_steps.train_model import TrainModelStep
-from opuspocus.utils import RunnerResources, open_file, read_shard, save_filestream
+from opuspocus.runner_resources import RunnerResources
+from opuspocus.utils import open_file, read_shard, save_filestream
 
 logger = logging.getLogger(__name__)
 

--- a/opuspocus/pipelines/__init__.py
+++ b/opuspocus/pipelines/__init__.py
@@ -5,6 +5,7 @@ from .exceptions import PipelineInitError
 from .opuspocus_pipeline import OpusPocusPipeline, PipelineState, PipelineStateError
 
 __all__ = ["OpusPocusPipeline", "PipelineInitError", "PipelineState", "PipelineStateError"]
+
 logger = logging.getLogger(__name__)
 
 

--- a/opuspocus/pipelines/__init__.py
+++ b/opuspocus/pipelines/__init__.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 def build_pipeline(args: argparse.Namespace) -> OpusPocusPipeline:
     logger.info("Building pipeline...")
-    return OpusPocusPipeline.build_pipeline(args.pipeline_config, args.pipeline_dir)
+    return OpusPocusPipeline.build_pipeline(args.pipeline_config, getattr(args.pipeline, "pipeline_dir", None))
 
 
 def load_pipeline(args: argparse.Namespace) -> OpusPocusPipeline:

--- a/opuspocus/pipelines/__init__.py
+++ b/opuspocus/pipelines/__init__.py
@@ -16,4 +16,4 @@ def build_pipeline(args: argparse.Namespace) -> OpusPocusPipeline:
 
 def load_pipeline(args: argparse.Namespace) -> OpusPocusPipeline:
     logger.info("Loading pipeline...")
-    return OpusPocusPipeline.load_pipeline(args.pipeline_dir)
+    return OpusPocusPipeline.load_pipeline(args.pipeline.pipeline_dir)

--- a/opuspocus/pipelines/opuspocus_pipeline.py
+++ b/opuspocus/pipelines/opuspocus_pipeline.py
@@ -124,7 +124,7 @@ class OpusPocusPipeline:
             )
             raise ValueError(err_msg)
         if self.pipeline_dir is None:
-            self.pipeline_dir = self.pipeline_config.pipeline.pipeline_dir
+            self.pipeline_dir = Path(self.pipeline_config.pipeline.pipeline_dir)
         elif self.pipeline_config is None:
             self.pipeline_config = PipelineConfig.load(Path(self.pipeline_dir, self._config_file))
         else:
@@ -142,8 +142,14 @@ class OpusPocusPipeline:
             help="Pipeline root directory location.",
         )
 
+    @classmethod
+    def get_config_file(cls: "OpusPocusPipeline") -> str:
+        """Config file name read-only accessor."""
+        return cls._config_file
+
     @property
     def pipeline_config_path(self) -> Path:
+        """Locations of the initialized pipeline's config."""
         return Path(self.pipeline_dir, self._config_file)
 
     @property

--- a/opuspocus/pipelines/opuspocus_pipeline.py
+++ b/opuspocus/pipelines/opuspocus_pipeline.py
@@ -10,7 +10,7 @@ from omegaconf import OmegaConf
 from opuspocus.config import PipelineConfig
 from opuspocus.pipeline_steps import OpusPocusStep, StepState, build_step, list_step_parameters
 from opuspocus.pipelines.exceptions import PipelineInitError, PipelineStateError
-from opuspocus.utils import clean_dir, file_path
+from opuspocus.utils import NestedAction, clean_dir, file_path
 
 logger = logging.getLogger(__name__)
 
@@ -137,9 +137,20 @@ class OpusPocusPipeline:
         parser.add_argument(
             "--pipeline-dir",
             type=file_path,
-            default=None,
+            dest="pipeline.pipeline_dir",
+            action=NestedAction,
+            default=argparse.SUPPRESS,
             required=pipeline_dir_required,
             help="Pipeline root directory location.",
+        )
+        parser.add_argument(
+            "--targets",
+            type=str,
+            dest="pipeline.targets",
+            action=NestedAction,
+            default=argparse.SUPPRESS,
+            nargs="+",
+            help="List of step labels to be executed together with ther dependencies.",
         )
 
     @classmethod

--- a/opuspocus/runner_resources.py
+++ b/opuspocus/runner_resources.py
@@ -3,7 +3,7 @@ import logging
 import os
 from typing import Any, Dict, List
 
-from attrs import converters, define, field, validators
+from attrs import define, field, validators
 
 logger = logging.getLogger(__name__)
 
@@ -38,10 +38,7 @@ class RunnerResources:
 
     @property
     def resource_dict(self) -> Dict[str, Any]:
-        return {
-            param: getattr(self, param)
-            for param in self.list_parameters()
-        }
+        return {param: getattr(self, param) for param in self.list_parameters()}
 
     @classmethod
     def get_env_name(cls: "RunnerResources", name: str) -> str:

--- a/opuspocus/runner_resources.py
+++ b/opuspocus/runner_resources.py
@@ -1,0 +1,55 @@
+import inspect
+import logging
+import os
+from typing import Dict, List
+
+logger = logging.getLogger(__name__)
+
+
+class RunnerResources:
+    """Runner-agnostic resources object.
+
+    This class aims at unifying various ways different schedulers represent
+    resources and resource variables.
+
+    TODO(varisd): add more resource attributes if necessary
+    """
+
+    def __init__(
+        self,
+        cpus: int = 1,
+        gpus: int = 0,
+        mem: str = "1g",
+    ) -> None:
+        self.cpus = cpus
+        self.gpus = gpus
+        self.mem = mem
+
+    @classmethod
+    def list_parameters(cls: "RunnerResources") -> List[str]:
+        """List all represented parameters."""
+        return [param for param in inspect.signature(cls.__init__).parameters if param != "self"]
+
+    def overwrite(self, resources: "RunnerResources") -> "RunnerResources":
+        """Overwrite the resources using a different RunnerResources object."""
+        res_dict = {}
+        for param in self.list_parameters():
+            res_dict[param] = getattr(self, param)
+            if hasattr(resources, param):
+                res_dict[param] = getattr(resources, param)
+        return RunnerResources(**res_dict)
+
+    @classmethod
+    def get_env_name(cls: "RunnerResources", name: str) -> str:
+        """Get the environment name of a specific resource parameter."""
+        assert name in cls.list_parameters()
+        return f"OPUSPOCUS_{name}"
+
+    def get_env_dict(self) -> Dict[str, str]:
+        """Get the dictionary with the resource environment variables."""
+        env_dict = {}
+        for param in self.list_parameters():
+            param_val = getattr(self, param)
+            if param_val is not None:
+                env_dict[self.get_env_name(param)] = str(param_val)
+        return {**os.environ.copy(), **env_dict}

--- a/opuspocus/runner_resources.py
+++ b/opuspocus/runner_resources.py
@@ -1,11 +1,14 @@
 import inspect
 import logging
 import os
-from typing import Dict, List
+from typing import Any, Dict, List
+
+from attrs import converters, define, field, validators
 
 logger = logging.getLogger(__name__)
 
 
+@define(kw_only=True)
 class RunnerResources:
     """Runner-agnostic resources object.
 
@@ -15,15 +18,9 @@ class RunnerResources:
     TODO(varisd): add more resource attributes if necessary
     """
 
-    def __init__(
-        self,
-        cpus: int = 1,
-        gpus: int = 0,
-        mem: str = "1g",
-    ) -> None:
-        self.cpus = cpus
-        self.gpus = gpus
-        self.mem = mem
+    cpus: int = field(validator=validators.instance_of(int), default=1)
+    gpus: int = field(validator=validators.instance_of(int), default=0)
+    mem: str = field(converter=str, default="1g")
 
     @classmethod
     def list_parameters(cls: "RunnerResources") -> List[str]:
@@ -38,6 +35,13 @@ class RunnerResources:
             if hasattr(resources, param):
                 res_dict[param] = getattr(resources, param)
         return RunnerResources(**res_dict)
+
+    @property
+    def resource_dict(self) -> Dict[str, Any]:
+        return {
+            param: getattr(self, param)
+            for param in self.list_parameters()
+        }
 
     @classmethod
     def get_env_name(cls: "RunnerResources", name: str) -> str:

--- a/opuspocus/runners/__init__.py
+++ b/opuspocus/runners/__init__.py
@@ -23,7 +23,7 @@ RUNNER_CLASS_NAMES = set()
 
 def build_runner(args: Namespace) -> OpusPocusRunner:
     """Runner builder function. Use this to create runner objects."""
-    runner = args.runner
+    runner = args.runner.runner
     assert runner is not None
     pipeline_dir = args.pipeline_dir
     assert pipeline_dir is not None

--- a/opuspocus/runners/__init__.py
+++ b/opuspocus/runners/__init__.py
@@ -25,7 +25,7 @@ def build_runner(args: Namespace) -> OpusPocusRunner:
     """Runner builder function. Use this to create runner objects."""
     runner = args.runner.runner
     assert runner is not None
-    pipeline_dir = args.pipeline_dir
+    pipeline_dir = getattr(args.pipeline, "pipeline_dir", None)
     assert pipeline_dir is not None
 
     logger.info("Building runner (%s) based on config in (%s)", runner, pipeline_dir)
@@ -52,7 +52,7 @@ def load_runner(args: Namespace) -> OpusPocusRunner:
     """Recreate a previously used runner. Required for pipeline execution
     updates, i.e. execution termination.
     """
-    pipeline_dir = args.pipeline_dir
+    pipeline_dir = getattr(args.pipeline, "pipeline_dir", None)
     assert pipeline_dir is not None
 
     runner_params = OpusPocusRunner.load_parameters(pipeline_dir)

--- a/opuspocus/runners/__init__.py
+++ b/opuspocus/runners/__init__.py
@@ -4,6 +4,9 @@ from argparse import Namespace
 from pathlib import Path
 from typing import Callable
 
+from opuspocus.config import PipelineConfig
+from opuspocus.pipelines import OpusPocusPipeline
+
 from .opuspocus_runner import OpusPocusRunner, SubmissionInfo, TaskInfo
 
 __all__ = [
@@ -18,24 +21,39 @@ RUNNER_REGISTRY = {}
 RUNNER_CLASS_NAMES = set()
 
 
-def build_runner(runner: str, pipeline_dir: Path, args: Namespace) -> OpusPocusRunner:
+def build_runner(args: Namespace) -> OpusPocusRunner:
     """Runner builder function. Use this to create runner objects."""
-    logger.info("Building runner (%s)...", runner)
+    runner = args.runner
+    assert runner is not None
+    pipeline_dir = args.pipeline_dir
+    assert pipeline_dir is not None
 
+    logger.info("Building runner (%s) based on config in (%s)", runner, pipeline_dir)
     kwargs = {}
+
+    config_path = Path(pipeline_dir, OpusPocusPipeline.get_config_file())
+    if config_path.exists():
+        config = PipelineConfig.load(Path(pipeline_dir, OpusPocusPipeline.get_config_file()))
+
+        kwargs = dict(config.runner)
+        del kwargs["runner"]
+
+    # NOTE(varisd): the following override should become obsolete after reimplementing CLI config override support
     for param in RUNNER_REGISTRY[runner].list_parameters():
         if param in {"runner", "pipeline_dir"}:
             continue
-        kwargs[param] = getattr(args, param)
+        kwargs[param] = getattr(args, f"runner.{param}")
 
     return RUNNER_REGISTRY[runner].build_runner(runner, pipeline_dir, **kwargs)
 
 
-def load_runner(pipeline_dir: Path) -> OpusPocusRunner:
+def load_runner(args: Namespace) -> OpusPocusRunner:
     """Recreate a previously used runner. Required for pipeline execution
     updates, i.e. execution termination.
-
     """
+    pipeline_dir = args.pipeline_dir
+    assert pipeline_dir is not None
+
     runner_params = OpusPocusRunner.load_parameters(pipeline_dir)
 
     runner = runner_params["runner"]

--- a/opuspocus/runners/__init__.py
+++ b/opuspocus/runners/__init__.py
@@ -42,7 +42,8 @@ def build_runner(args: Namespace) -> OpusPocusRunner:
     for param in RUNNER_REGISTRY[runner].list_parameters():
         if param in {"runner", "pipeline_dir"}:
             continue
-        kwargs[param] = getattr(args, f"runner.{param}")
+        if hasattr(kwargs, param):
+            kwargs[param] = getattr(args.runner, param)
 
     return RUNNER_REGISTRY[runner].build_runner(runner, pipeline_dir, **kwargs)
 

--- a/opuspocus/runners/bash.py
+++ b/opuspocus/runners/bash.py
@@ -10,8 +10,9 @@ from typing import List, Optional
 from attrs import define, field, validators
 from psutil import NoSuchProcess, Process, wait_procs
 
+from opuspocus.runner_resources import RunnerResources
 from opuspocus.runners import OpusPocusRunner, TaskInfo, register_runner
-from opuspocus.utils import RunnerResources, subprocess_wait
+from opuspocus.utils import subprocess_wait
 
 logger = logging.getLogger(__name__)
 

--- a/opuspocus/runners/bash.py
+++ b/opuspocus/runners/bash.py
@@ -49,7 +49,7 @@ class BashRunner(OpusPocusRunner):
         cmd_path: Path,
         target_file: Optional[Path] = None,
         dependencies: Optional[List[BashTaskInfo]] = None,
-        step_resources: Optional[RunnerResources] = None,
+        task_resources: Optional[RunnerResources] = None,
         stdout_file: Optional[Path] = None,
         stderr_file: Optional[Path] = None,
     ) -> BashTaskInfo:
@@ -65,7 +65,7 @@ class BashRunner(OpusPocusRunner):
             cmd_path (Path): location of the step's command to be executed
             target_file (Path): target_file to be created by a subtask (if not None)
             dependencies (List[BashTaskInfo]): list of task information about the running dependencies
-            step_resources (RunnerResources): resources to be allocated for the task
+            task_resources (RunnerResources): resources to be allocated for the task
             stdout_file (Path): location of the log file for task's stdout
             stderr_file (Path): location of the log file for task's stderr
 
@@ -75,7 +75,7 @@ class BashRunner(OpusPocusRunner):
         dependencies_str = ""
         if dependencies is not None:
             dependencies_str = " ".join([str(dep["id"]) for dep in dependencies])
-        env_dict = step_resources.get_env_dict()
+        env_dict = task_resources.get_env_dict()
 
         stdout = sys.stdout
         if stdout_file is not None:

--- a/opuspocus/runners/bash.py
+++ b/opuspocus/runners/bash.py
@@ -35,8 +35,9 @@ class BashRunner(OpusPocusRunner):
     def add_args(parser: ArgumentParser) -> None:
         """Add runner-specific arguments to the parser."""
         OpusPocusRunner.add_args(parser)
-        parser.add_argument(
-            "--run-tasks-in-parallel",
+        OpusPocusRunner.add_runner_argument(
+            parser,
+            "run_tasks_in_parallel",
             default=False,
             action="store_true",
             help="Submit tasks as processes running in parallel wherever possible.",

--- a/opuspocus/runners/debug.py
+++ b/opuspocus/runners/debug.py
@@ -39,7 +39,7 @@ class DebugRunner(OpusPocusRunner):
         cmd_path: Path,
         target_file: Optional[Path] = None,
         dependencies: Optional[List[TaskInfo]] = None,  # noqa: ARG002
-        step_resources: Optional[RunnerResources] = None,
+        task_resources: Optional[RunnerResources] = None,
         stdout_file: Optional[Path] = None,  # noqa: ARG002
         stderr_file: Optional[Path] = None,  # noqa: ARG002
     ) -> TaskInfo:
@@ -51,7 +51,7 @@ class DebugRunner(OpusPocusRunner):
 
         # Process a specific target file
         if target_file is not None:
-            os.environ = step_resources.get_env_dict()  # noqa: B003
+            os.environ = task_resources.get_env_dict()  # noqa: B003
             step.command(target_file)
             return TaskInfo(file_path=target_file, id=-1)
 
@@ -66,7 +66,7 @@ class DebugRunner(OpusPocusRunner):
                 cmd_path=cmd_path,
                 target_file=t_file,
                 dependencies=None,
-                step_resources=self.get_resources(step),
+                task_resources=self.get_resources(step),
             )
         step.main_task_postprocess()
         clean_dir(step.tmp_dir)

--- a/opuspocus/runners/debug.py
+++ b/opuspocus/runners/debug.py
@@ -4,8 +4,9 @@ from pathlib import Path
 from typing import List, Optional
 
 from opuspocus.pipeline_steps import StepState, load_step
+from opuspocus.runner_resources import RunnerResources
 from opuspocus.runners import OpusPocusRunner, TaskInfo
-from opuspocus.utils import RunnerResources, clean_dir
+from opuspocus.utils import clean_dir
 
 logger = logging.getLogger(__name__)
 

--- a/opuspocus/runners/opuspocus_runner.py
+++ b/opuspocus/runners/opuspocus_runner.py
@@ -38,7 +38,7 @@ class OpusPocusRunner:
     runner: str = field(validator=validators.instance_of(str))
     pipeline_dir: Path = field(converter=Path)
     default_resources: RunnerResources = field(
-        converter=converters.optional(RunnerResources), default=RunnerResources()
+        validator=validators.instance_of(RunnerResources), default=RunnerResources()
     )
 
     _parameter_filename = "runner.parameters"
@@ -86,6 +86,9 @@ class OpusPocusRunner:
         Returns:
             An instance of the specified runner class.
         """
+        if "default_resources" in kwargs:
+            kwargs["default_resources"] = RunnerResources(**kwargs["default_resources"])
+
         return cls(runner=runner, pipeline_dir=pipeline_dir, **kwargs)
 
     @classmethod
@@ -130,6 +133,8 @@ class OpusPocusRunner:
         for attr, value in asdict(self, filter=lambda attr, _: not attr.name.startswith("_")).items():
             if isinstance(value, Path):
                 param_dict[attr] = str(value)
+            elif isinstance(value, RunnerResources):
+                param_dict[attr] = value.resource_dict
             elif isinstance(value, (list, tuple)) and any(isinstance(v, Path) for v in value):
                 param_dict[attr] = [str(v) for v in value]
             else:

--- a/opuspocus/runners/opuspocus_runner.py
+++ b/opuspocus/runners/opuspocus_runner.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import yaml
-from attrs import asdict, converters, define, field, fields, validators
+from attrs import asdict, define, field, fields, validators
 from typing_extensions import TypedDict
 
 from opuspocus.pipeline_steps import OpusPocusStep, StepState
@@ -37,7 +37,9 @@ class OpusPocusRunner:
 
     runner: str = field(validator=validators.instance_of(str))
     pipeline_dir: Path = field(converter=Path)
-    runner_resources: RunnerResources = field(validator=validators.instance_of(RunnerResources))
+    runner_resources: RunnerResources = field(
+        validator=validators.instance_of(RunnerResources), default=RunnerResources()
+    )
 
     _parameter_filename = "runner.parameters"
     _info_filename = "runner.step_info"
@@ -86,6 +88,11 @@ class OpusPocusRunner:
         """
         if "runner_resources" in kwargs:
             kwargs["runner_resources"] = RunnerResources(**kwargs["runner_resources"])
+        else:
+            logger.debug(
+                "[OpusPocusRunner] Global runner resources were not provided."
+                "Using the default RunnerResources values."
+            )
 
         return cls(runner=runner, pipeline_dir=pipeline_dir, **kwargs)
 
@@ -404,8 +411,8 @@ class OpusPocusRunner:
 
     def get_resources(self, step: OpusPocusStep) -> RunnerResources:
         """Get default runner resources."""
-        if step.resources is not None:
+        if step.runner_resources is not None:
             # Get step-specific resources if available
-            return step.resources
+            return step.runner_resources
         # Otherwise, use the global resources
-        return self.default_resources
+        return self.runner_resources

--- a/opuspocus/runners/opuspocus_runner.py
+++ b/opuspocus/runners/opuspocus_runner.py
@@ -5,8 +5,9 @@ from argparse import ArgumentParser
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+import json
 import yaml
-from attrs import asdict, define, field, fields, validators
+from attrs import asdict, converters, define, field, fields, validators
 from typing_extensions import TypedDict
 
 from opuspocus.pipeline_steps import OpusPocusStep, StepState
@@ -35,6 +36,7 @@ class OpusPocusRunner:
 
     runner: str = field(validator=validators.instance_of(str))
     pipeline_dir: Path = field(converter=Path)
+    default_resources: RunnerResources = field(converter=converters.optional(RunnerResources))
 
     _parameter_filename = "runner.parameters"
     _info_filename = "runner.step_info"
@@ -42,7 +44,13 @@ class OpusPocusRunner:
     @staticmethod
     def add_args(parser: ArgumentParser) -> None:
         """Add runner-specific arguments to the parser."""
-        pass
+        OpusPocusRunner.add_runner_argument(
+            parser,
+            "default_resources",
+            type=json.loads,
+            default=None,
+            help="Global task execution resource assignmnet."
+        )
 
     @staticmethod
     def add_runner_argument(parser: ArgumentParser, arg_name: str, **kwargs) -> None:  # noqa: ANN003

--- a/opuspocus/runners/opuspocus_runner.py
+++ b/opuspocus/runners/opuspocus_runner.py
@@ -177,7 +177,9 @@ class OpusPocusRunner:
     def run_pipeline(
         self,
         pipeline: OpusPocusPipeline,
-        args: argparse.Namespace,
+        target_labels: Optional[List[str]] = None,
+        *,
+        resubmit_done: bool = False,
     ) -> None:
         """Submit and execute pipeline steps with labels in target_labels and their dependencies.
 
@@ -187,8 +189,8 @@ class OpusPocusRunner:
             resubmit_done (bool): should we resubmit finished subtasks of a failed task
         """
         self.save_parameters()
-        for step in pipeline.get_targets(getattr(args.pipeline, "targets", None)):
-            self.submit_step(step, resubmit_finished_subtasks=args.resubmit_finished_subtasks)
+        for step in pipeline.get_targets(target_labels):
+            self.submit_step(step, resubmit_finished_subtasks=resubmit_done)
         logger.info("[%s] Pipeline tasks submitted successfully.", self.runner)
 
     def submit_step(self, step: OpusPocusStep, *, resubmit_finished_subtasks: bool = True) -> Optional[SubmissionInfo]:

--- a/opuspocus/runners/opuspocus_runner.py
+++ b/opuspocus/runners/opuspocus_runner.py
@@ -44,6 +44,16 @@ class OpusPocusRunner:
         """Add runner-specific arguments to the parser."""
         pass
 
+    @staticmethod
+    def add_runner_argument(parser: ArgumentParser, arg_name: str, **kwargs) -> None:  # noqa: ANN003
+        """Wrapper for adding runner arguments that get stored in the proper OmegaConf destination.
+
+        To guarantee backwards compatibility, we still support the `--runner_arg` syntax.
+        However, the new syntax using `runner.runner_arg` should be preferred.
+        """
+        arg_name_hyphens = "-".join(arg_name.split("_"))
+        parser.add_argument(f"--{arg_name_hyphens}", dest=f"runner.{arg_name}", **kwargs)
+
     @classmethod
     def build_runner(cls: "OpusPocusRunner", runner: str, pipeline_dir: Path, **kwargs) -> "OpusPocusRunner":  # noqa: ANN003
         """Build a specified runner instance.

--- a/opuspocus/runners/opuspocus_runner.py
+++ b/opuspocus/runners/opuspocus_runner.py
@@ -177,9 +177,7 @@ class OpusPocusRunner:
     def run_pipeline(
         self,
         pipeline: OpusPocusPipeline,
-        target_labels: Optional[List[str]] = None,
-        *,
-        resubmit_finished_subtasks: bool = False,
+        args: argparse.Namespace,
     ) -> None:
         """Submit and execute pipeline steps with labels in target_labels and their dependencies.
 
@@ -189,8 +187,8 @@ class OpusPocusRunner:
             resubmit_done (bool): should we resubmit finished subtasks of a failed task
         """
         self.save_parameters()
-        for step in pipeline.get_targets(target_labels):
-            self.submit_step(step, resubmit_finished_subtasks=resubmit_finished_subtasks)
+        for step in pipeline.get_targets(getattr(args.pipeline, "targets", None)):
+            self.submit_step(step, resubmit_finished_subtasks=args.resubmit_finished_subtasks)
         logger.info("[%s] Pipeline tasks submitted successfully.", self.runner)
 
     def submit_step(self, step: OpusPocusStep, *, resubmit_finished_subtasks: bool = True) -> Optional[SubmissionInfo]:

--- a/opuspocus/runners/opuspocus_runner.py
+++ b/opuspocus/runners/opuspocus_runner.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import signal
 import time
@@ -5,14 +6,13 @@ from argparse import ArgumentParser
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-import json
 import yaml
 from attrs import asdict, converters, define, field, fields, validators
 from typing_extensions import TypedDict
 
 from opuspocus.pipeline_steps import OpusPocusStep, StepState
 from opuspocus.pipelines import OpusPocusPipeline
-from opuspocus.utils import RunnerResources
+from opuspocus.runner_resources import RunnerResources
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +36,9 @@ class OpusPocusRunner:
 
     runner: str = field(validator=validators.instance_of(str))
     pipeline_dir: Path = field(converter=Path)
-    default_resources: RunnerResources = field(converter=converters.optional(RunnerResources))
+    default_resources: RunnerResources = field(
+        converter=converters.optional(RunnerResources), default=RunnerResources()
+    )
 
     _parameter_filename = "runner.parameters"
     _info_filename = "runner.step_info"
@@ -49,7 +51,7 @@ class OpusPocusRunner:
             "default_resources",
             type=json.loads,
             default=None,
-            help="Global task execution resource assignmnet."
+            help="Global task execution resource assignmnet.",
         )
 
     @staticmethod

--- a/opuspocus/runners/slurm.py
+++ b/opuspocus/runners/slurm.py
@@ -60,7 +60,7 @@ class SlurmRunner(OpusPocusRunner):
         cmd_path: Path,
         target_file: Optional[Path] = None,
         dependencies: Optional[List[SlurmTaskInfo]] = None,
-        step_resources: Optional[RunnerResources] = None,
+        task_resources: Optional[RunnerResources] = None,
         stdout_file: Optional[Path] = None,
         stderr_file: Optional[Path] = None,
     ) -> SlurmTaskInfo:
@@ -70,7 +70,7 @@ class SlurmRunner(OpusPocusRunner):
             cmd_path (Path): location of the step's command to be executed
             target_file (Path): target_file to be created by a subtask (if not None)
             dependencies (List[SlurmTaskInfo]): list of task information about the running dependencies
-            step_resources (RunnerResources): resources to be allocated for the task
+            task_resources (RunnerResources): resources to be allocated for the task
             stdout_file (Path): location of the log file for task's stdout
             stderr_file (Path): location of the log file for task's stderr
 
@@ -88,8 +88,7 @@ class SlurmRunner(OpusPocusRunner):
             cmd.append("--dependency")
             cmd.append(",".join([f"afterok:{dep!s}" for dep in dependencies_ids]))
 
-        # TODO: fix this with resource config refactor
-        # cmd += self._convert_resources(step_resources)
+        cmd += self._convert_resources(task_resources)
 
         jobname = f"{self.runner}.{self.pipeline_dir.stem}{self.pipeline_dir.suffix}"
         if target_file is not None:
@@ -114,12 +113,12 @@ class SlurmRunner(OpusPocusRunner):
         if target_file is not None:
             cmd += [str(cmd_path), str(target_file)]
             proc = subprocess.Popen(
-                cmd, stdout=subprocess.PIPE, stderr=sys.stderr, shell=False, env=step_resources.get_env_dict()
+                cmd, stdout=subprocess.PIPE, stderr=sys.stderr, shell=False, env=task_resources.get_env_dict()
             )
         else:
             cmd += [str(cmd_path)]
             proc = subprocess.Popen(
-                cmd, stdout=subprocess.PIPE, stderr=sys.stderr, shell=False, env=step_resources.get_env_dict()
+                cmd, stdout=subprocess.PIPE, stderr=sys.stderr, shell=False, env=task_resources.get_env_dict()
             )
         logger.info("Submitted sbatch command: %s", " ".join(cmd))
 

--- a/opuspocus/runners/slurm.py
+++ b/opuspocus/runners/slurm.py
@@ -11,8 +11,9 @@ from attrs import Attribute, define, field, validators
 
 from opuspocus.pipeline_steps import OpusPocusStep
 from opuspocus.pipelines import OpusPocusPipeline
+from opuspocus.runner_resources import RunnerResources
 from opuspocus.runners import OpusPocusRunner, TaskInfo, register_runner
-from opuspocus.utils import RunnerResources, subprocess_wait
+from opuspocus.utils import subprocess_wait
 
 logger = logging.getLogger(__name__)
 

--- a/opuspocus/runners/slurm.py
+++ b/opuspocus/runners/slurm.py
@@ -51,6 +51,7 @@ class SlurmRunner(OpusPocusRunner):
     def add_args(parser):  # noqa: ANN001, ANN205
         """Add runner-specific arguments to the parser."""
         OpusPocusRunner.add_args(parser)
+        OpusPocusRunner.add_runner_argument(parser, "slurm_time", type=str, default=None, help="Slurm job time limit.")
         OpusPocusRunner.add_runner_argument(
             parser, "slurm_other_options", type=str, default=None, help="Additional Slurm CLI options."
         )

--- a/opuspocus/runners/slurm.py
+++ b/opuspocus/runners/slurm.py
@@ -34,7 +34,7 @@ class SlurmRunner(OpusPocusRunner):
     commands.
     """
 
-    slurm_time: str = field()
+    slurm_time: str = field(validator=validators.optional(validators.instance_of(str)), default=None)
     slurm_other_options: str = field(validator=validators.optional(validators.instance_of(str)), default=None)
 
     @slurm_time.validator

--- a/opuspocus/runners/slurm.py
+++ b/opuspocus/runners/slurm.py
@@ -50,13 +50,8 @@ class SlurmRunner(OpusPocusRunner):
     def add_args(parser):  # noqa: ANN001, ANN205
         """Add runner-specific arguments to the parser."""
         OpusPocusRunner.add_args(parser)
-        parser.add_argument("--slurm-time", type=str, default=None, help="Slurm job time limit.")
-        parser.add_argument(
-            "--slurm-other-options",
-            type=str,
-            metavar="RUNNER",
-            default=None,
-            help="Additional Slurm CLI options (catchall for less frequent options).",
+        OpusPocusRunner.add_runner_argument(
+            parser, "slurm_other_options", type=str, default=None, help="Additional Slurm CLI options."
         )
 
     def submit_task(

--- a/opuspocus/utils.py
+++ b/opuspocus/utils.py
@@ -46,14 +46,14 @@ class NestedAction(argparse.Action):
 class NestedActionStoreTrue(NestedAction):
     def __call__(
         self,
-        parser: argparse.ArgumentParser,
+        parser: argparse.ArgumentParser,  # noqa: ARG002
         namespace: argparse.Namespace,
-        values: Any,
-        option_string: Optional[str] = None
+        values: Any,  # noqa: ARG002,ANN401
+        option_string: Optional[str] = None,  # noqa: ARG002
     ) -> None:
         dest_split = self.dest.split(".")
         assert len(dest_split) > 1
-        self._group_actions(namespace, dest_split[0], dest_split[1:], True)
+        self._group_actions(namespace=namespace, group=dest_split[0], dest_arr=dest_split[1:], values=True)
 
 
 def open_file(file: Path, mode: str) -> TextIO:

--- a/opuspocus/utils.py
+++ b/opuspocus/utils.py
@@ -1,11 +1,9 @@
 import gzip
-import inspect
 import logging
-import os
 import subprocess
 import time
 from pathlib import Path
-from typing import Any, Dict, List, TextIO
+from typing import List, TextIO
 
 logger = logging.getLogger(__name__)
 
@@ -160,50 +158,3 @@ def file_path(path_str):  # noqa: ANN001, ANN201
         return path.absolute()
     else:  # noqa: RET505
         raise FileNotFoundError(path)
-
-
-class RunnerResources:
-    """Runner-agnostic resources object.
-
-    This class aims at unifying various ways different schedulers represent
-    resources and resource variables.
-    """
-
-    def __init__(
-        self,
-        cpus: int = 1,
-        gpus: int = 0,
-        mem: str = "1g",
-    ) -> None:
-        self.cpus = cpus
-        self.gpus = gpus
-        self.mem = mem
-
-    @classmethod
-    def list_parameters(cls: "RunnerResources") -> List[str]:
-        """List all represented parameters."""
-        return [param for param in inspect.signature(cls.__init__).parameters if param != "self"]
-
-    def overwrite(self, resources: "RunnerResources") -> "RunnerResources":
-        """Overwrite the resources using a different RunnerResources object."""
-        res_dict = {}
-        for param in self.list_parameters():
-            res_dict[param] = getattr(self, param)
-            if hasattr(resources, param):
-                res_dict[param] = getattr(resources, param)
-        return RunnerResources(**res_dict)
-
-    @classmethod
-    def get_env_name(cls: "RunnerResources", name: str) -> str:
-        """Get the environment name of a specific resource parameter."""
-        assert name in cls.list_parameters()
-        return f"OPUSPOCUS_{name}"
-
-    def get_env_dict(self) -> Dict[str, str]:
-        """Get the dictionary with the resource environment variables."""
-        env_dict = {}
-        for param in self.list_parameters():
-            param_val = getattr(self, param)
-            if param_val is not None:
-                env_dict[self.get_env_name(param)] = str(param_val)
-        return {**os.environ.copy(), **env_dict}

--- a/opuspocus/utils.py
+++ b/opuspocus/utils.py
@@ -1,11 +1,59 @@
+import argparse
 import gzip
 import logging
 import subprocess
 import time
 from pathlib import Path
-from typing import List, TextIO
+from typing import Any, List, Optional, TextIO
 
 logger = logging.getLogger(__name__)
+
+
+class NestedAction(argparse.Action):
+    """Implements a support for creating nested argparse.Namespace.
+
+    The nested structure is indicated by a dot (".") notation in the action destination,
+    e.g. `dest=group.argument` creates a nested Namespace
+    Namespace(group=Namespace(argument=argument_value)).
+
+    NOTE(varisd): This class is currently in the opuspocus.utils instead of opuspocus.options to avoid circural
+    imports.
+    """
+
+    def _group_actions(self, namespace: argparse.Namespace, group: str, dest_arr: List[str], values: Any) -> None:  # noqa: ANN401
+        """Process the dest_arr separated destination array, depth-first."""
+        groupspace = getattr(namespace, group, argparse.Namespace())
+        if len(dest_arr) > 1:
+            # Call the method recursively if not at the final level of recursion
+            self._group_actions(groupspace, dest_arr[0], dest_arr[1:], values)
+        else:
+            # Otherwise assign the values at the final level under the given key
+            setattr(groupspace, dest_arr[0], values)
+        setattr(namespace, group, groupspace)
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,  # noqa: ARG002
+        namespace: argparse.Namespace,
+        values: Any,  # noqa: ANN401
+        option_string: Optional[str] = None,  # noqa: ARG002
+    ) -> None:
+        dest_split = self.dest.split(".")
+        assert len(dest_split) > 1
+        self._group_actions(namespace, dest_split[0], dest_split[1:], values)
+
+
+class NestedActionStoreTrue(NestedAction):
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: Any,
+        option_string: Optional[str] = None
+    ) -> None:
+        dest_split = self.dest.split(".")
+        assert len(dest_split) > 1
+        self._group_actions(namespace, dest_split[0], dest_split[1:], True)
 
 
 def open_file(file: Path, mode: str) -> TextIO:

--- a/opuspocus/utils.py
+++ b/opuspocus/utils.py
@@ -184,15 +184,14 @@ class RunnerResources:
         """List all represented parameters."""
         return [param for param in inspect.signature(cls.__init__).parameters if param != "self"]
 
-    def overwrite(self, resource_dict: Dict[str, Any]) -> "RunnerResources":
+    def overwrite(self, resources: "RunnerResources") -> "RunnerResources":
         """Overwrite the resources using a different RunnerResources object."""
-        params = {}
+        res_dict = {}
         for param in self.list_parameters():
-            val = getattr(self, param)
-            if param in resource_dict:
-                val = resource_dict[param]
-            params[param] = val
-        return RunnerResources(**params)
+            res_dict[param] = getattr(self, param)
+            if hasattr(resources, param):
+                res_dict[param] = getattr(resources, param)
+        return RunnerResources(**res_dict)
 
     @classmethod
     def get_env_name(cls: "RunnerResources", name: str) -> str:

--- a/opuspocus_cli/run.py
+++ b/opuspocus_cli/run.py
@@ -29,7 +29,7 @@ def init_pipeline(pipeline: OpusPocusPipeline, args: Namespace) -> OpusPocusPipe
         logger.info("Re-initializing the pipeline...")
         if pipeline.state in [PipelineState.RUNNING, PipelineState.SUBMITTED]:
             logger.info("Stopping the previous run...")
-            prev_runner = load_runner(Namespace(**{"pipeline_dir": pipeline.pipeline_dir}))
+            prev_runner = load_runner(Namespace(**{"pipeline": Namespace(**{"pipeline_dir": pipeline.pipeline_dir})}))
             prev_runner.stop_pipeline(pipeline)
         pipeline.reinit(ignore_finished=args.reinit_failed)
     return pipeline
@@ -116,7 +116,9 @@ def main(args: Namespace) -> int:
         )
         sys.exit(2)
 
-    runner.run_pipeline(pipeline, args)
+    runner.run_pipeline(
+        pipeline, target_labels=getattr(args.pipeline, "targets", None), resubmit_done=args.resubmit_finished_subtasks
+    )
     return 0
 
 

--- a/opuspocus_cli/run.py
+++ b/opuspocus_cli/run.py
@@ -79,7 +79,7 @@ def main(args: Namespace) -> int:
     ## Run phase ##
     # Get default runner value from the config if not provided via CLI
     if args.runner is None:
-        args.runner = config.runner.runner
+        args.runner.runner = config.runner.runner
 
     runner = build_runner(args)
 

--- a/opuspocus_cli/stop.py
+++ b/opuspocus_cli/stop.py
@@ -45,7 +45,7 @@ def main(args: Namespace) -> int:
         )
 
     if pipeline.state not in [StepState.INITED, StepState.INIT_INCOMPLETE]:
-        runner = load_runner(args.pipeline_dir)
+        runner = load_runner(args)
         logger.info("Stopping pipeline...")
         runner.stop_pipeline(pipeline)
     return 0

--- a/opuspocus_cli/traceback.py
+++ b/opuspocus_cli/traceback.py
@@ -18,7 +18,7 @@ def main(args: Namespace) -> int:
     with their current status.
     """
     pipeline = load_pipeline(args)
-    pipeline.print_traceback(target_labels=args.targets)
+    pipeline.print_traceback(target_labels=getattr(args.pipeline, "targets", None))
     return 0
 
 

--- a/tests/fixtures/pipelines.py
+++ b/tests/fixtures/pipelines.py
@@ -86,14 +86,14 @@ def foo_pipeline_running(foo_pipeline_inited):
         s.sleep_time = 180
         s.save_parameters()
     runner = build_runner(
-        Namespace(
-            **{
-                "runner.runner": "bash",
-                "pipeline_dir": foo_pipeline_inited.pipeline_dir,
-                "runner.run_tasks_in_parallel": True,
-                "runner.default_resources": None,
-            }
-        )
+        Namespace(**{
+            "runner": Namespace(**{
+                "runner": "bash",
+                "run_tasks_in_parallel": True,
+                "default_resources": None
+            }),
+            "pipeline_dir": foo_pipeline_inited.pipeline_dir,
+        })
     )
     runner.run_pipeline(foo_pipeline_inited, None)
     return foo_pipeline_inited
@@ -103,14 +103,14 @@ def foo_pipeline_running(foo_pipeline_inited):
 def foo_pipeline_done(foo_pipeline_inited):
     """Basic mock pipeline (DONE)."""
     runner = build_runner(
-        Namespace(
-            **{
-                "runner.runner": "bash",
-                "pipeline_dir": foo_pipeline_inited.pipeline_dir,
-                "runner.run_tasks_in_parallel": True,
-                "runner.default_resources": None,
-            }
-        )
+        Namespace(**{
+            "runner": Namespace(**{
+                "runner": "bash",
+                "run_tasks_in_parallel": True,
+                "default_resources": None
+            }),
+            "pipeline_dir": foo_pipeline_inited.pipeline_dir,
+        })
     )
     runner.run_pipeline(foo_pipeline_inited)
     tasks = [runner.load_submission_info(s)["main_task"] for s in foo_pipeline_inited.steps]

--- a/tests/fixtures/pipelines.py
+++ b/tests/fixtures/pipelines.py
@@ -86,14 +86,12 @@ def foo_pipeline_running(foo_pipeline_inited):
         s.sleep_time = 180
         s.save_parameters()
     runner = build_runner(
-        Namespace(**{
-            "runner": Namespace(**{
-                "runner": "bash",
-                "run_tasks_in_parallel": True,
-                "default_resources": None
-            }),
-            "pipeline_dir": foo_pipeline_inited.pipeline_dir,
-        })
+        Namespace(
+            **{
+                "runner": Namespace(**{"runner": "bash", "run_tasks_in_parallel": True, "runner_resources": None}),
+                "pipeline_dir": foo_pipeline_inited.pipeline_dir,
+            }
+        )
     )
     runner.run_pipeline(foo_pipeline_inited, None)
     return foo_pipeline_inited
@@ -103,14 +101,12 @@ def foo_pipeline_running(foo_pipeline_inited):
 def foo_pipeline_done(foo_pipeline_inited):
     """Basic mock pipeline (DONE)."""
     runner = build_runner(
-        Namespace(**{
-            "runner": Namespace(**{
-                "runner": "bash",
-                "run_tasks_in_parallel": True,
-                "default_resources": None
-            }),
-            "pipeline_dir": foo_pipeline_inited.pipeline_dir,
-        })
+        Namespace(
+            **{
+                "runner": Namespace(**{"runner": "bash", "run_tasks_in_parallel": True, "runner_resources": None}),
+                "pipeline_dir": foo_pipeline_inited.pipeline_dir,
+            }
+        )
     )
     runner.run_pipeline(foo_pipeline_inited)
     tasks = [runner.load_submission_info(s)["main_task"] for s in foo_pipeline_inited.steps]

--- a/tests/fixtures/pipelines.py
+++ b/tests/fixtures/pipelines.py
@@ -88,8 +88,14 @@ def foo_pipeline_running(foo_pipeline_inited):
     runner = build_runner(
         Namespace(
             **{
-                "runner": Namespace(**{"runner": "bash", "run_tasks_in_parallel": True, "runner_resources": None}),
-                "pipeline_dir": foo_pipeline_inited.pipeline_dir,
+                "runner": Namespace(
+                    **{
+                        "runner": "bash",
+                        "run_tasks_in_parallel": True,
+                        "runner_resources": None,
+                    }
+                ),
+                "pipeline": Namespace(**{"pipeline_dir": foo_pipeline_inited.pipeline_dir}),
             }
         )
     )
@@ -104,7 +110,7 @@ def foo_pipeline_done(foo_pipeline_inited):
         Namespace(
             **{
                 "runner": Namespace(**{"runner": "bash", "run_tasks_in_parallel": True, "runner_resources": None}),
-                "pipeline_dir": foo_pipeline_inited.pipeline_dir,
+                "pipeline": Namespace(**{"pipeline_dir": foo_pipeline_inited.pipeline_dir}),
             }
         )
     )
@@ -133,7 +139,7 @@ def pipeline_preprocess_tiny(
     args = Namespace(
         **{
             "pipeline_config": pipeline_preprocess_tiny_config_file,
-            "pipeline_dir": pipeline_dir,
+            "pipeline": Namespace(**{"pipeline_dir": pipeline_dir}),
         }
     )
     pipeline = build_pipeline(args)
@@ -168,7 +174,7 @@ def pipeline_train_tiny(
     args = Namespace(
         **{
             "pipeline_config": pipeline_train_tiny_config_file,
-            "pipeline_dir": pipeline_dir,
+            "pipeline": Namespace(**{"pipeline_dir": pipeline_dir}),
         }
     )
     pipeline = build_pipeline(args)

--- a/tests/fixtures/pipelines.py
+++ b/tests/fixtures/pipelines.py
@@ -86,11 +86,14 @@ def foo_pipeline_running(foo_pipeline_inited):
         s.sleep_time = 180
         s.save_parameters()
     runner = build_runner(
-        Namespace(**{
-            "runner": "bash",
-            "pipeline_dir": foo_pipeline_inited.pipeline_dir,
-            "runner.run_tasks_in_parallel": True
-        })
+        Namespace(
+            **{
+                "runner.runner": "bash",
+                "pipeline_dir": foo_pipeline_inited.pipeline_dir,
+                "runner.run_tasks_in_parallel": True,
+                "runner.default_resources": None,
+            }
+        )
     )
     runner.run_pipeline(foo_pipeline_inited, None)
     return foo_pipeline_inited
@@ -100,11 +103,14 @@ def foo_pipeline_running(foo_pipeline_inited):
 def foo_pipeline_done(foo_pipeline_inited):
     """Basic mock pipeline (DONE)."""
     runner = build_runner(
-        Namespace(**{
-            "runner": "bash",
-            "pipeline_dir": foo_pipeline_inited.pipeline_dir,
-            "runner.run_tasks_in_parallel": True
-        })
+        Namespace(
+            **{
+                "runner": "bash",
+                "pipeline_dir": foo_pipeline_inited.pipeline_dir,
+                "runner.run_tasks_in_parallel": True,
+                "runner.default_resources": None,
+            }
+        )
     )
     runner.run_pipeline(foo_pipeline_inited)
     tasks = [runner.load_submission_info(s)["main_task"] for s in foo_pipeline_inited.steps]

--- a/tests/fixtures/pipelines.py
+++ b/tests/fixtures/pipelines.py
@@ -85,11 +85,12 @@ def foo_pipeline_running(foo_pipeline_inited):
     for s in foo_pipeline_inited.steps:
         s.sleep_time = 180
         s.save_parameters()
-    pipeline_dir = foo_pipeline_inited.pipeline_dir
     runner = build_runner(
-        "bash",
-        pipeline_dir,
-        Namespace(**{"runner": "bash", "pipeline_dir": str(pipeline_dir), "run_tasks_in_parallel": True}),
+        Namespace(**{
+            "runner": "bash",
+            "pipeline_dir": foo_pipeline_inited.pipeline_dir,
+            "runner.run_tasks_in_parallel": True
+        })
     )
     runner.run_pipeline(foo_pipeline_inited, None)
     return foo_pipeline_inited
@@ -98,11 +99,12 @@ def foo_pipeline_running(foo_pipeline_inited):
 @pytest.fixture()
 def foo_pipeline_done(foo_pipeline_inited):
     """Basic mock pipeline (DONE)."""
-    pipeline_dir = foo_pipeline_inited.pipeline_dir
     runner = build_runner(
-        "bash",
-        pipeline_dir,
-        Namespace(**{"runner": "bash", "pipeline_dir": str(pipeline_dir), "run_tasks_in_parallel": True}),
+        Namespace(**{
+            "runner": "bash",
+            "pipeline_dir": foo_pipeline_inited.pipeline_dir,
+            "runner.run_tasks_in_parallel": True
+        })
     )
     runner.run_pipeline(foo_pipeline_inited)
     tasks = [runner.load_submission_info(s)["main_task"] for s in foo_pipeline_inited.steps]

--- a/tests/fixtures/pipelines.py
+++ b/tests/fixtures/pipelines.py
@@ -105,7 +105,7 @@ def foo_pipeline_done(foo_pipeline_inited):
     runner = build_runner(
         Namespace(
             **{
-                "runner": "bash",
+                "runner.runner": "bash",
                 "pipeline_dir": foo_pipeline_inited.pipeline_dir,
                 "runner.run_tasks_in_parallel": True,
                 "runner.default_resources": None,

--- a/tests/fixtures/runners.py
+++ b/tests/fixtures/runners.py
@@ -28,4 +28,4 @@ def parsed_runner_args(request, foo_step):
 @pytest.fixture()
 def foo_runner(parsed_runner_args):
     """Create a mock runner."""
-    return build_runner(parsed_runner_args.runner, parsed_runner_args.pipeline_dir, parsed_runner_args)
+    return build_runner(parsed_runner_args)

--- a/tests/opuspocus/pipelines/test_pipelines.py
+++ b/tests/opuspocus/pipelines/test_pipelines.py
@@ -20,7 +20,7 @@ def test_build_pipeline_method(
     args = Namespace(
         **{
             "pipeline_config": pipeline_preprocess_tiny_config_file,
-            "pipeline_dir": pipeline_dir,
+            "pipeline": Namespace(**{"pipeline_dir": pipeline_dir}),
         }
     )
     pipeline = build_pipeline(args)
@@ -30,14 +30,14 @@ def test_build_pipeline_method(
 
 def test_load_pipeline_method(pipeline_preprocess_tiny_inited):
     """Load previously created pipeline and compare the two instances."""
-    args = Namespace(**{"pipeline_dir": Path(pipeline_preprocess_tiny_inited.pipeline_dir)})
+    args = Namespace(**{"pipeline": Namespace(**{"pipeline_dir": Path(pipeline_preprocess_tiny_inited.pipeline_dir)})})
     pipeline = load_pipeline(args)
     assert pipeline.pipeline_graph == pipeline_preprocess_tiny_inited.pipeline_graph
 
 
 def test_load_pipeline_dir_not_exist():
     """Fail when trying to load pipeline not previously inited."""
-    args = Namespace(**{"pipeline_dir": Path("nonexistent", "directory")})
+    args = Namespace(**{"pipeline": Namespace(**{"pipeline_dir": Path("nonexistent", "directory")})})
     with pytest.raises(FileNotFoundError):
         load_pipeline(args)
 
@@ -46,10 +46,14 @@ def test_load_pipeline_dir_not_directory(pipeline_preprocess_tiny_inited):
     """Fail when trying to load pipeline from invalid directory."""
     args = Namespace(
         **{
-            "pipeline_dir": Path(
-                pipeline_preprocess_tiny_inited.pipeline_dir,
-                pipeline_preprocess_tiny_inited._config_file,  # noqa: SLF001
-            ),
+            "pipeline": Namespace(
+                **{
+                    "pipeline_dir": Path(
+                        pipeline_preprocess_tiny_inited.pipeline_dir,
+                        pipeline_preprocess_tiny_inited._config_file,  # noqa: SLF001
+                    ),
+                }
+            )
         }
     )
     with pytest.raises(NotADirectoryError):

--- a/tests/opuspocus/runners/test_runners.py
+++ b/tests/opuspocus/runners/test_runners.py
@@ -1,4 +1,5 @@
 import time
+from argparse import Namespace
 from pathlib import Path
 
 import pytest
@@ -29,14 +30,14 @@ def test_build_runner_method(foo_runner):
 def test_load_runner_before_save_fail(pipeline_preprocess_tiny_inited):
     """Fail loading runner that was not previously created."""
     with pytest.raises(FileNotFoundError):
-        load_runner(pipeline_preprocess_tiny_inited.pipeline_dir)
+        load_runner(Namespace(**{"pipeline_dir": pipeline_preprocess_tiny_inited.pipeline_dir}))
 
 
 def test_load_runner_method(foo_runner):
     """Reload runner for further pipeline execution manipulation."""
     foo_runner.save_parameters()
 
-    runner_loaded = load_runner(foo_runner.pipeline_dir)
+    runner_loaded = load_runner(Namespace(**{"pipeline_dir": foo_runner.pipeline_dir}))
     assert foo_runner == runner_loaded
 
 

--- a/tests/opuspocus/runners/test_runners.py
+++ b/tests/opuspocus/runners/test_runners.py
@@ -30,14 +30,16 @@ def test_build_runner_method(foo_runner):
 def test_load_runner_before_save_fail(pipeline_preprocess_tiny_inited):
     """Fail loading runner that was not previously created."""
     with pytest.raises(FileNotFoundError):
-        load_runner(Namespace(**{"pipeline_dir": pipeline_preprocess_tiny_inited.pipeline_dir}))
+        load_runner(
+            Namespace(**{"pipeline": Namespace(**{"pipeline_dir": pipeline_preprocess_tiny_inited.pipeline_dir})})
+        )
 
 
 def test_load_runner_method(foo_runner):
     """Reload runner for further pipeline execution manipulation."""
     foo_runner.save_parameters()
 
-    runner_loaded = load_runner(Namespace(**{"pipeline_dir": foo_runner.pipeline_dir}))
+    runner_loaded = load_runner(Namespace(**{"pipeline": Namespace(**{"pipeline_dir": foo_runner.pipeline_dir})}))
     assert foo_runner == runner_loaded
 
 

--- a/tests/opuspocus_cli/test_cli.py
+++ b/tests/opuspocus_cli/test_cli.py
@@ -67,4 +67,4 @@ def test_required_pipeline_dir_option(cmd_name, capsys):
     assert err.value.code != 0
 
     output = capsys.readouterr()
-    assert " --pipeline-dir PIPELINE_DIR" in output.out
+    assert " --pipeline-dir PIPELINE.PIPELINE_DIR" in output.out


### PR DESCRIPTION
- Reimplemented RunnerResources class (now in a separate module)
- Each pipeline step can have its own runner resources defined in the config, default is None (in such case, the global, runner's runner_resources are used)
- added support for "nested" parser actions (similar to the OmegaConf
- moved pipeline and runner-related argument destination to args.pipeline.* and args.runner.* to comply with the current config structure